### PR TITLE
Use IEnumerable<dynamic> instead of dynamic for collections

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/Queries/IOrderQueries.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Queries/IOrderQueries.cs
@@ -1,13 +1,14 @@
 ﻿namespace Microsoft.eShopOnContainers.Services.Ordering.API.Application.Queries
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public interface IOrderQueries
     {
         Task<dynamic> GetOrderAsync(int id);
 
-        Task<dynamic> GetOrdersAsync();
+        Task<IEnumerable<dynamic>> GetOrdersAsync();
 
-        Task<dynamic> GetCardTypesAsync();
+        Task<IEnumerable<dynamic>> GetCardTypesAsync();
     }
 }

--- a/src/Services/Ordering/Ordering.API/Application/Queries/OrderQueries.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Queries/OrderQueries.cs
@@ -44,13 +44,13 @@
             }
         }
 
-        public Task<IEnumerable<dynamic>> GetOrdersAsync()
+        public async Task<IEnumerable<dynamic>> GetOrdersAsync()
         {
             using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
-                return connection.QueryAsync<dynamic>(@"SELECT o.[Id] as ordernumber,o.[OrderDate] as [date],os.[Name] as [status],SUM(oi.units*oi.unitprice) as total
+                return await connection.QueryAsync<dynamic>(@"SELECT o.[Id] as ordernumber,o.[OrderDate] as [date],os.[Name] as [status],SUM(oi.units*oi.unitprice) as total
                      FROM [ordering].[Orders] o
                      LEFT JOIN[ordering].[orderitems] oi ON  o.Id = oi.orderid 
                      LEFT JOIN[ordering].[orderstatus] os on o.OrderStatusId = os.Id
@@ -58,13 +58,13 @@
             }
         }
 
-        public Task<IEnumerable<dynamic>> GetCardTypesAsync()
+        public async Task<IEnumerable<dynamic>> GetCardTypesAsync()
         {
             using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
-                return connection.QueryAsync<dynamic>("SELECT * FROM ordering.cardtypes");
+                return await connection.QueryAsync<dynamic>("SELECT * FROM ordering.cardtypes");
             }
         }
 

--- a/src/Services/Ordering/Ordering.API/Application/Queries/OrderQueries.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Queries/OrderQueries.cs
@@ -44,13 +44,13 @@
             }
         }
 
-        public async Task<dynamic> GetOrdersAsync()
+        public Task<IEnumerable<dynamic>> GetOrdersAsync()
         {
             using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
-                return await connection.QueryAsync<dynamic>(@"SELECT o.[Id] as ordernumber,o.[OrderDate] as [date],os.[Name] as [status],SUM(oi.units*oi.unitprice) as total
+                return connection.QueryAsync<dynamic>(@"SELECT o.[Id] as ordernumber,o.[OrderDate] as [date],os.[Name] as [status],SUM(oi.units*oi.unitprice) as total
                      FROM [ordering].[Orders] o
                      LEFT JOIN[ordering].[orderitems] oi ON  o.Id = oi.orderid 
                      LEFT JOIN[ordering].[orderstatus] os on o.OrderStatusId = os.Id
@@ -58,13 +58,13 @@
             }
         }
 
-        public async Task<dynamic> GetCardTypesAsync()
+        public Task<IEnumerable<dynamic>> GetCardTypesAsync()
         {
             using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
-                return await connection.QueryAsync<dynamic>("SELECT * FROM ordering.cardtypes");
+                return connection.QueryAsync<dynamic>("SELECT * FROM ordering.cardtypes");
             }
         }
 

--- a/src/Services/Ordering/Ordering.API/Controllers/OrdersController.cs
+++ b/src/Services/Ordering/Ordering.API/Controllers/OrdersController.cs
@@ -68,8 +68,9 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.API.Controllers
         [HttpGet]
         public async Task<IActionResult> GetOrders()
         {
-            var orders = await _orderQueries
-                .GetOrdersAsync();
+            var orderTask = _orderQueries.GetOrdersAsync();
+
+            var orders = await orderTask;
 
             return Ok(orders);
         }

--- a/test/Services/UnitTest/Ordering/Application/OrdersWebApiTest.cs
+++ b/test/Services/UnitTest/Ordering/Application/OrdersWebApiTest.cs
@@ -6,6 +6,7 @@ using Microsoft.eShopOnContainers.Services.Ordering.API.Controllers;
 using Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure.Services;
 using Moq;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -59,7 +60,7 @@ namespace UnitTest.Ordering.Application
         public async Task Get_orders_success()
         {
             //Arrange
-            var fakeDynamicResult = new Object();
+            var fakeDynamicResult = Enumerable.Empty<object>();
             _orderQueriesMock.Setup(x => x.GetOrdersAsync())
                 .Returns(Task.FromResult(fakeDynamicResult));
 
@@ -92,7 +93,7 @@ namespace UnitTest.Ordering.Application
         public async Task Get_cardTypes_success()
         {
             //Arrange
-            var fakeDynamicResult = new Object();
+            var fakeDynamicResult = Enumerable.Empty<object>();
             _orderQueriesMock.Setup(x => x.GetCardTypesAsync())
                 .Returns(Task.FromResult(fakeDynamicResult));
 


### PR DESCRIPTION
This fixes the problem introduced in the prior PR by adding back the async state machines to the ordering queries.  See second commit for details.

/cc @CESARDELATORRE 