### PR TITLE
StandardHttpClient setting Authentication Header

### DIFF
--- a/src/BuildingBlocks/Resilience/Resilience.Http/StandardHttpClient.cs
+++ b/src/BuildingBlocks/Resilience/Resilience.Http/StandardHttpClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.Resilience.Http
                 throw new ArgumentException("Value must be either post or put.", nameof(method));
             }
 
-            // a new StringContent must be created for each retry 
+            // a new StringContent must be created for each retry
             // as it is disposed after each call
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -59,7 +59,7 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.Resilience.Http
 
             var response = await _client.SendAsync(requestMessage);
 
-            // raise exception if HttpResponseCode 500 
+            // raise exception if HttpResponseCode 500
             // needed for circuit breaker to track fails
 
             if (response.StatusCode == HttpStatusCode.InternalServerError)
@@ -73,12 +73,12 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.Resilience.Http
 
         public async Task<HttpResponseMessage> PostAsync<T>(string uri, T item, string authorizationToken = null, string requestId = null, string authorizationMethod = "Bearer")
         {
-            return await DoPostPutAsync(HttpMethod.Post, uri, item, authorizationToken, requestId, authorizationToken);
+            return await DoPostPutAsync(HttpMethod.Post, uri, item, authorizationToken, requestId, authorizationMethod);
         }
 
         public async Task<HttpResponseMessage> PutAsync<T>(string uri, T item, string authorizationToken = null, string requestId = null, string authorizationMethod = "Bearer")
         {
-            return await DoPostPutAsync(HttpMethod.Put, uri, item, authorizationToken, requestId, authorizationToken);
+            return await DoPostPutAsync(HttpMethod.Put, uri, item, authorizationToken, requestId, authorizationMethod);
         }
         public async Task<HttpResponseMessage> DeleteAsync(string uri, string authorizationToken = null, string requestId = null, string authorizationMethod = "Bearer")
         {


### PR DESCRIPTION
In a couple of places the AuthenticationToken is being used instead of the AuthenticationMethod parameter.  This results in failed requests.