### PR TITLE
Update Identity.API/Startup.cs

### DIFF
--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -40,7 +40,7 @@ namespace eShopOnContainers.Identity
             if (env.IsDevelopment())
             {
                 // For more details on using the user secret store see http://go.microsoft.com/fwlink/?LinkID=532709
-                builder.AddUserSecrets();
+                builder.AddUserSecrets<Startup>();
             }
 
             builder.AddEnvironmentVariables();


### PR DESCRIPTION
The more general `builder.AddUserSecrets();` is deprecated and will not be available in ASP.NET Core 2.0. You must now qualify it with a type parameter. 