### PR TITLE
Configure packages directory for restored NuGet packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
   <packageSources>
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
All solutions now restore to the packages directory at the root of
the repository. This fixes packages being restored into the
src/Mobile/packages directory when the eShopOnContainers.Xamarin.sln
is opened.

https://developercommunity.visualstudio.com/content/problem/80508/references-are-broken-even-though-nugets-have-been.html