### PR TITLE
CLI-Windows using wrong dll names in Dockerfile.nanowin

### DIFF
--- a/src/Services/Location/Locations.API/Dockerfile.nanowin
+++ b/src/Services/Location/Locations.API/Dockerfile.nanowin
@@ -5,4 +5,4 @@ WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Locations.API.dll"]

--- a/src/Services/Marketing/Marketing.API/Dockerfile.nanowin
+++ b/src/Services/Marketing/Marketing.API/Dockerfile.nanowin
@@ -5,4 +5,4 @@ WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Marketing.API.dll"]

--- a/src/Services/Payment/Payment.API/Dockerfile.nanowin
+++ b/src/Services/Payment/Payment.API/Dockerfile.nanowin
@@ -5,4 +5,4 @@ WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Payment.API.dll"]

--- a/src/Web/WebStatus/Dockerfile.nanowin
+++ b/src/Web/WebStatus/Dockerfile.nanowin
@@ -5,4 +5,4 @@ WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "WebMVC.dll"]
+ENTRYPOINT ["dotnet", "WebStatus.dll"]


### PR DESCRIPTION
CLI-Windows using wrong dll names in Dockerfile.nanowin
Looks like nobody have tested windows version for a long time