### PR TITLE
dotnet restore not needed in cli 2.0

### DIFF
--- a/cli-mac/build-bits.sh
+++ b/cli-mac/build-bits.sh
@@ -22,8 +22,6 @@ do
     echo -e "\e[33m\tRemoving old publish output"
     pushd $(pwd)/$project
     rm -rf obj/Docker/publish
-    echo -e "\e[33m\tRestoring project"
-    dotnet restore
     echo -e "\e[33m\tBuilding and publishing projects"
     dotnet publish -o obj/Docker/publish -c Release
     popd

--- a/cli-windows/build-bits-simple.ps1
+++ b/cli-windows/build-bits-simple.ps1
@@ -13,7 +13,5 @@ Write-Host "Root path used is $rootPath" -ForegroundColor Yellow
 
 $SolutionFilePath = [IO.Path]::Combine($rootPath, "eShopOnContainers-ServicesAndWebApps.sln")
 
-dotnet restore $SolutionFilePath
-
 dotnet publish $SolutionFilePath -c Release -o .\obj\Docker\publish
 

--- a/cli-windows/build-bits.ps1
+++ b/cli-windows/build-bits.ps1
@@ -31,7 +31,6 @@ $projectPaths =
         #Write-Host "Deleting old publish files in $outPath" -ForegroundColor Yellow
         remove-item -path $outPath -Force -Recurse -ErrorAction SilentlyContinue
         #Write-Host "Publishing $projectPathAndFile to $outPath" -ForegroundColor Yellow
-        dotnet build $projectPathAndFile
         dotnet publish $projectPathAndFile -o $outPath -c Release
     }
 }

--- a/k8s/deploy.ps1
+++ b/k8s/deploy.ps1
@@ -54,7 +54,6 @@ Write-Host "Docker image Tag: $imageTag" -ForegroundColor Yellow
 # building and publishing docker images if needed
 if($buildBits) {
     Write-Host "Building and publishing eShopOnContainers..." -ForegroundColor Yellow
-    dotnet restore ../eShopOnContainers-ServicesAndWebApps.sln
     dotnet publish -c Release -o obj/Docker/publish ../eShopOnContainers-ServicesAndWebApps.sln
 }
 if ($buildImages) {


### PR DESCRIPTION
"Starting with .NET Core 2.0 SDK, dotnet restore runs implicitily when you run dotnet build." (C) https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build?tabs=netcore2x