### PR TITLE
Parallel dotnet build process.

### DIFF
--- a/cli-windows/build-bits.ps1
+++ b/cli-windows/build-bits.ps1
@@ -8,6 +8,9 @@ if ([string]::IsNullOrEmpty($rootPath)) {
 }
 Write-Host "Root path used is $rootPath" -ForegroundColor Yellow
 
+workflow BuildAndPublish {
+    param ([string] $rootPath
+    )
 $projectPaths = 
     @{Path="$rootPath\src\Web\WebMVC";Prj="WebMVC.csproj"},
     @{Path="$rootPath\src\Web\WebSPA";Prj="WebSPA.csproj"},
@@ -21,19 +24,20 @@ $projectPaths =
     @{Path="$rootPath\src\Services\Payment\Payment.API";Prj="Payment.API.csproj"},
     @{Path="$rootPath\src\Web\WebStatus";Prj="WebStatus.csproj"}
 
-$projectPaths | foreach {
-    $projectPath = $_.Path
-    $projectFile = $_.Prj
-    $outPath = $_.Path + "\obj\Docker\publish"
-    $projectPathAndFile = "$projectPath\$projectFile"
-    Write-Host "Deleting old publish files in $outPath" -ForegroundColor Yellow
-    remove-item -path $outPath -Force -Recurse -ErrorAction SilentlyContinue
-    Write-Host "Publishing $projectPathAndFile to $outPath" -ForegroundColor Yellow
-    dotnet restore $projectPathAndFile
-    dotnet build $projectPathAndFile
-    dotnet publish $projectPathAndFile -o $outPath
+    foreach -parallel ($item in $projectPaths) {
+        $projectPath = $item.Path
+        $projectFile = $item.Prj
+        $outPath = $item.Path + "\obj\Docker\publish"
+        $projectPathAndFile = "$projectPath\$projectFile"
+        #Write-Host "Deleting old publish files in $outPath" -ForegroundColor Yellow
+        remove-item -path $outPath -Force -Recurse -ErrorAction SilentlyContinue
+        #Write-Host "Publishing $projectPathAndFile to $outPath" -ForegroundColor Yellow
+        dotnet build $projectPathAndFile
+        dotnet publish $projectPathAndFile -o $outPath 
+    }
 }
 
+BuildAndPublish $rootPath
 
 ########################################################################################
 # Delete old eShop Docker images


### PR DESCRIPTION
it's working 2m 24s instead of 3m 48s (sequential execution)
theis only one problem... write-host not working inside the workflow
P.S. in both cases comparison was without "dotnet restore command", because it's not mandatory in .net core sdk 2.0
