### PR TITLE
Fix "DRY up RedisBasketRepository"

### DIFF
--- a/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/ProductPriceChangedIntegrationEventHandler.cs
+++ b/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/ProductPriceChangedIntegrationEventHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.IntegrationEvents.Even
 
         public async Task Handle(ProductPriceChangedIntegrationEvent @event)
         {
-            var userIds = await _repository.GetUsersAsync();
+            var userIds = _repository.GetUsers();
             
             foreach (var id in userIds)
             {

--- a/src/Services/Basket/Basket.API/Model/IBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Model/IBasketRepository.cs
@@ -6,7 +6,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Model
     public interface IBasketRepository
     {
         Task<CustomerBasket> GetBasketAsync(string customerId);
-        Task<IEnumerable<string>> GetUsersAsync();
+        IEnumerable<string> GetUsers();
         Task<CustomerBasket> UpdateBasketAsync(CustomerBasket basket);
         Task<bool> DeleteBasketAsync(string id);
     }

--- a/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
+++ b/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
@@ -1,4 +1,6 @@
 ﻿
+using StackExchange.Redis;
+
 namespace IntegrationTests.Services.Basket
 {
     using Microsoft.eShopOnContainers.Services.Basket.API;
@@ -57,10 +59,9 @@ namespace IntegrationTests.Services.Basket
         RedisBasketRepository BuildBasketRepository()
         {
             var loggerFactory = new LoggerFactory();            
-            var basketSettings = new BasketSettings() { ConnectionString = "127.0.0.1" };
-            _optionsMock.Setup(x => x.Value).Returns(basketSettings);
-            
-            return new RedisBasketRepository(_optionsMock.Object, loggerFactory);
+            var configuration = ConfigurationOptions.Parse("127.0.0.1", true);
+            configuration.ResolveDns = true;
+            return new RedisBasketRepository(loggerFactory, ConnectionMultiplexer.Connect(configuration));
         }
 
         List<BasketItem> BuildBasketItems()


### PR DESCRIPTION
https://github.com/dotnet-architecture/eShopOnContainers/issues/62

I made some clean-up for the RedisBasketRepository.
1) Removing `GetDatabase` from the methods
2) Inject `ConnectionMultiplexer` through constructor injection.
There are some lines in `Startup.cs`
```csharp
services.AddSingleton<ConnectionMultiplexer>(sp =>
{
	var settings = sp.GetRequiredService<IOptions<BasketSettings>>().Value;
	ConfigurationOptions configuration = ConfigurationOptions.Parse(settings.ConnectionString, true);           
	configuration.ResolveDns = true;

	return ConnectionMultiplexer.Connect(configuration);
});
```
Why don't use them? :)
3) `GetUsersAsync` -> `GetUsers`. 'cause there is no need for async after implementing constructor injection
4) Refactoring calls of `GetUsersAsync` method