### PR TITLE
release publish configuration for win/mac, because for Linux it's already done

### DIFF
--- a/cli-mac/build-bits.sh
+++ b/cli-mac/build-bits.sh
@@ -25,7 +25,7 @@ do
     echo -e "\e[33m\tRestoring project"
     dotnet restore
     echo -e "\e[33m\tBuilding and publishing projects"
-    dotnet publish -o obj/Docker/publish
+    dotnet publish -o obj/Docker/publish -c Release
     popd
 done
 

--- a/cli-windows/build-bits.ps1
+++ b/cli-windows/build-bits.ps1
@@ -31,7 +31,7 @@ $projectPaths | foreach {
     Write-Host "Publishing $projectPathAndFile to $outPath" -ForegroundColor Yellow
     dotnet restore $projectPathAndFile
     dotnet build $projectPathAndFile
-    dotnet publish $projectPathAndFile -o $outPath
+    dotnet publish $projectPathAndFile -o $outPath -c Release
 }
 
 


### PR DESCRIPTION
release publish configuration for win/mac, because for Linux it's already done