### PR TITLE
Update project list in mac build script

### DIFF
--- a/cli-mac/build-bits.sh
+++ b/cli-mac/build-bits.sh
@@ -3,12 +3,15 @@
 # List of microservices here needs to be updated to include all the new microservices (Marketing, etc.)
 
 projectList=(
-    "../src/Services/Catalog/Catalog.API"
-    "../src/Services/Basket/Basket.API"
-    "../src/Services/Ordering/Ordering.API"
-    "../src/Services/Identity/Identity.API"
     "../src/Web/WebMVC"
     "../src/Web/WebSPA"
+    "../src/Services/Identity/Identity.API"
+    "../src/Services/Catalog/Catalog.API"
+    "../src/Services/Ordering/Ordering.API"
+    "../src/Services/Basket/Basket.API"
+    "../src/Services/Location/Locations.API"
+    "../src/Services/Marketing/Marketing.API"
+    "../src/Services/Payment/Payment.API"
     "../src/Web/WebStatus"
 )
 


### PR DESCRIPTION
I confirmed that this allows the project to build on Mac, excluding WebSPA which I didn't test. [See comment](https://github.com/dotnet-architecture/eShopOnContainers/issues/107#issuecomment-339161921) for details.

Also note that I had to install bower for this to work which isn't listed in the pre-requisites.

Finally, the [documentation](https://github.com/dotnet-architecture/eShopOnContainers/wiki/04.-Setting-eShopOnContainer-solution-up-in-a-Mac,-VS-Code-and-CLI-environment--(dotnet-CLI,-Docker-CLI-and-VS-Code)#running-the-application) can be updated as well. The list outlining where all the services can be reached is out of date, and in the case of WebSPA, incorrect.