### PR TITLE
Fix build errors & warnings

### DIFF
--- a/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
+++ b/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
@@ -31,7 +31,7 @@
             });
 
             Assert.NotNull(basket);
-            Assert.Equal(1, basket.Items.Count);
+            Assert.Single(basket.Items);
         }
 
         [Fact]

--- a/test/Services/IntegrationTests/Services/Catalog/CatalogScenarios.cs
+++ b/test/Services/IntegrationTests/Services/Catalog/CatalogScenarios.cs
@@ -41,7 +41,7 @@ namespace IntegrationTests.Services.Catalog
                 var response = await server.CreateClient()
                     .GetAsync(Get.ItemById(int.MinValue));
 
-                Assert.Equal(response.StatusCode, HttpStatusCode.BadRequest);
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             }
         }
 
@@ -53,7 +53,7 @@ namespace IntegrationTests.Services.Catalog
                 var response = await server.CreateClient()
                     .GetAsync(Get.ItemById(int.MaxValue));
 
-                Assert.Equal(response.StatusCode, HttpStatusCode.NotFound);
+                Assert.Equal( HttpStatusCode.NotFound, response.StatusCode);
             }
         }
 

--- a/test/Services/UnitTest/Ordering/Application/OrdersWebApiTest.cs
+++ b/test/Services/UnitTest/Ordering/Application/OrdersWebApiTest.cs
@@ -93,7 +93,7 @@ namespace UnitTest.Ordering.Application
         public async Task Get_orders_success()
         {
             //Arrange
-            var fakeDynamicResult = Enumerable.Empty<object>();
+            var fakeDynamicResult = Enumerable.Empty<OrderSummary>();
             _orderQueriesMock.Setup(x => x.GetOrdersAsync())
                 .Returns(Task.FromResult(fakeDynamicResult));
 
@@ -110,7 +110,7 @@ namespace UnitTest.Ordering.Application
         {
             //Arrange
             var fakeOrderId = 123;
-            var fakeDynamicResult = new Object();
+            var fakeDynamicResult = new Order();
             _orderQueriesMock.Setup(x => x.GetOrderAsync(It.IsAny<int>()))
                 .Returns(Task.FromResult(fakeDynamicResult));
 
@@ -126,7 +126,7 @@ namespace UnitTest.Ordering.Application
         public async Task Get_cardTypes_success()
         {
             //Arrange
-            var fakeDynamicResult = Enumerable.Empty<object>();
+            var fakeDynamicResult = Enumerable.Empty<CardType>();
             _orderQueriesMock.Setup(x => x.GetCardTypesAsync())
                 .Returns(Task.FromResult(fakeDynamicResult));
 

--- a/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
+++ b/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
@@ -111,7 +111,6 @@ public class OrderAggregateTest
     public void Add_new_Order_raises_new_event()
     {
         //Arrange
-        var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";
@@ -135,7 +134,6 @@ public class OrderAggregateTest
     public void Add_event_Order_explicitly_raises_new_event()
     {
         //Arrange   
-        var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";
@@ -159,7 +157,6 @@ public class OrderAggregateTest
     public void Remove_event_Order_explicitly()
     {
         //Arrange    
-        var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";


### PR DESCRIPTION
I tried to build the latest code with [these instructions](https://github.com/dotnet-architecture/eShopOnContainers/wiki/03.-Setting-the-eShopOnContainers-solution-up-in-a-Windows-CLI-environment-(dotnet-CLI,-Docker-CLI-and-VS-Code)) and saw the following issues in the build log:

```
Ordering/Application/OrdersWebApiTest.cs(98,26): error CS1503: Argument 1: cannot convert from 'System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<object>>' to 'System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.eShopOnContainers.Services.Ordering.API.Application.Queries.OrderSummary>>'
Ordering/Application/OrdersWebApiTest.cs(115,26): error CS1503: Argument 1: cannot convert from 'System.Threading.Tasks.Task<object>' to 'System.Threading.Tasks.Task<Microsoft.eShopOnContainers.Services.Ordering.API.Application.Queries.Order>'
Ordering/Application/OrdersWebApiTest.cs(131,26): error CS1503: Argument 1: cannot convert from 'System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<object>>' to 'System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.eShopOnContainers.Services.Ordering.API.Application.Queries.CardType>>'
```

They appear to be due to the changes in 5e1346731561fd0612cf76ec7fe4e34cf32ebb00.

This PR fixes those build errors, as well as the xUnit and csc warnings.

(FWIW I still get `eshoponcontainers_ci-build_1 exited with code 1` when running `docker-compose -f docker-compose.ci.build.yml up` but I don't see any other obvious problems in my build log.)