### PR TITLE
Fix about some async calls.

### DIFF
--- a/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
+++ b/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
@@ -1,6 +1,7 @@
 ﻿using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
 using Microsoft.eShopOnContainers.Services.Identity.API.Configuration;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,33 +25,22 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API.Data
                 {"OrderingApi", configuration.GetValue<string>("OrderingApiClient")}
             };
 
-            if (!context.Clients.Any())
+            if (!await context.Clients.AnyAsync())
             {
-                foreach (var client in Config.GetClients(clientUrls))
-                {
-                    await context.Clients.AddAsync(client.ToEntity());
-                }
-                await context.SaveChangesAsync();
+                context.Clients.AddRange(Config.GetClients(clientUrls).Select(client => client.ToEntity()));
             }
 
-            if (!context.IdentityResources.Any())
+            if (!await context.IdentityResources.AnyAsync())
             {
-                foreach (var resource in Config.GetResources())
-                {
-                    await context.IdentityResources.AddAsync(resource.ToEntity());
-                }
-                await context.SaveChangesAsync();
+                context.IdentityResources.AddRange(Config.GetResources().Select(resource => resource.ToEntity()));
             }
 
-            if (!context.ApiResources.Any())
+            if (!await context.ApiResources.AnyAsync())
             {
-                foreach (var api in Config.GetApis())
-                {
-                    await context.ApiResources.AddAsync(api.ToEntity());
-                }
-
-                await context.SaveChangesAsync();
+                context.ApiResources.AddRange(Config.GetApis().Select(api => api.ToEntity()));
             }
+
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
+++ b/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
@@ -10,19 +10,19 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API.Data
 {
     public class ConfigurationDbContextSeed
     {
-        public async Task SeedAsync(ConfigurationDbContext context,IConfiguration configuration)
+        public async Task SeedAsync(ConfigurationDbContext context, IConfiguration configuration)
         {
-           
             //callbacks urls from config:
-            var clientUrls = new Dictionary<string, string>();
-
-            clientUrls.Add("Mvc", configuration.GetValue<string>("MvcClient"));
-            clientUrls.Add("Spa", configuration.GetValue<string>("SpaClient"));
-            clientUrls.Add("Xamarin", configuration.GetValue<string>("XamarinCallback"));
-            clientUrls.Add("LocationsApi", configuration.GetValue<string>("LocationApiClient"));
-            clientUrls.Add("MarketingApi", configuration.GetValue<string>("MarketingApiClient"));
-            clientUrls.Add("BasketApi", configuration.GetValue<string>("BasketApiClient"));
-            clientUrls.Add("OrderingApi", configuration.GetValue<string>("OrderingApiClient"));
+            var clientUrls = new Dictionary<string, string>
+            {
+                {"Mvc", configuration.GetValue<string>("MvcClient")},
+                {"Spa", configuration.GetValue<string>("SpaClient")},
+                {"Xamarin", configuration.GetValue<string>("XamarinCallback")},
+                {"LocationsApi", configuration.GetValue<string>("LocationApiClient")},
+                {"MarketingApi", configuration.GetValue<string>("MarketingApiClient")},
+                {"BasketApi", configuration.GetValue<string>("BasketApiClient")},
+                {"OrderingApi", configuration.GetValue<string>("OrderingApiClient")}
+            };
 
             if (!context.Clients.Any())
             {


### PR DESCRIPTION
The `DbSet<T>.Any()` is a database I/O operation, it's should be async.
But the `DbSet<T>.AddAsync<T>(T entity)` is only used to allow special value generators, in the document:

> This method is async only to allow special value generators, such as the one used by  'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo', to access the database asynchronously. For all other cases the non async method should be used.

So I think it should be non async.