### PR TITLE
Add reference packages to TestRunner app so it builds successfully

### DIFF
--- a/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/eShopOnContainers.TestRunner.iOS.csproj
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/eShopOnContainers.TestRunner.iOS.csproj
@@ -147,6 +147,69 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.10.0.3\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Plugin.Geolocator.Abstractions">
+      <HintPath>..\..\..\..\packages\Xam.Plugin.Geolocator.3.0.4\lib\Xamarin.iOS10\Plugin.Geolocator.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.Geolocator">
+      <HintPath>..\..\..\..\packages\Xam.Plugin.Geolocator.3.0.4\lib\Xamarin.iOS10\Plugin.Geolocator.dll</HintPath>
+    </Reference>
+    <Reference Include="SlideOverKit">
+      <HintPath>..\..\..\..\packages\SlideOverKit.2.1.5\lib\Xamarin.iOS10\SlideOverKit.dll</HintPath>
+    </Reference>
+    <Reference Include="SlideOverKit.iOS">
+      <HintPath>..\..\..\..\packages\SlideOverKit.2.1.5\lib\Xamarin.iOS10\SlideOverKit.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="IdentityModel">
+      <HintPath>..\..\..\..\packages\IdentityModel.3.0.0\lib\netstandard2.0\IdentityModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Acr.Support.iOS">
+      <HintPath>..\..\..\..\packages\Acr.Support.2.1.0\lib\Xamarin.iOS10\Acr.Support.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="BTProgressHUD">
+      <HintPath>..\..\..\..\packages\BTProgressHUD.1.2.0.5\lib\Xamarin.iOS10\BTProgressHUD.dll</HintPath>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\..\..\..\packages\Splat.2.0.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+    </Reference>
+    <Reference Include="Acr.UserDialogs">
+      <HintPath>..\..\..\..\packages\Acr.UserDialogs.6.5.1\lib\Xamarin.iOS10\Acr.UserDialogs.dll</HintPath>
+    </Reference>
+    <Reference Include="Acr.UserDialogs.Interface">
+      <HintPath>..\..\..\..\packages\Acr.UserDialogs.6.5.1\lib\Xamarin.iOS10\Acr.UserDialogs.Interface.dll</HintPath>
+    </Reference>
+    <Reference Include="WebP.Touch">
+      <HintPath>..\..\..\..\packages\WebP.Touch.1.0.7\lib\Xamarin.iOS10\WebP.Touch.dll</HintPath>
+    </Reference>
+    <Reference Include="FFImageLoading">
+      <HintPath>..\..\..\..\packages\Xamarin.FFImageLoading.2.3.4\lib\Xamarin.iOS10\FFImageLoading.dll</HintPath>
+    </Reference>
+    <Reference Include="FFImageLoading.Platform">
+      <HintPath>..\..\..\..\packages\Xamarin.FFImageLoading.2.3.4\lib\Xamarin.iOS10\FFImageLoading.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="FFImageLoading.Forms">
+      <HintPath>..\..\..\..\packages\Xamarin.FFImageLoading.Forms.2.3.4\lib\Xamarin.iOS10\FFImageLoading.Forms.dll</HintPath>
+    </Reference>
+    <Reference Include="FFImageLoading.Forms.Touch">
+      <HintPath>..\..\..\..\packages\Xamarin.FFImageLoading.Forms.2.3.4\lib\Xamarin.iOS10\FFImageLoading.Forms.Touch.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.Windows.Core">
+      <HintPath>..\..\..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.Kernel32">
+      <HintPath>..\..\..\..\packages\PInvoke.Kernel32.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Kernel32.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.BCrypt">
+      <HintPath>..\..\..\..\packages\PInvoke.BCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.BCrypt.dll</HintPath>
+    </Reference>
+    <Reference Include="PInvoke.NCrypt">
+      <HintPath>..\..\..\..\packages\PInvoke.NCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.NCrypt.dll</HintPath>
+    </Reference>
+    <Reference Include="Validation">
+      <HintPath>..\..\..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
+    </Reference>
+    <Reference Include="PCLCrypto">
+      <HintPath>..\..\..\..\packages\PCLCrypto.2.0.147\lib\xamarinios10\PCLCrypto.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Entitlements.plist" />

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/packages.config
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/packages.config
@@ -1,10 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Acr.Support" version="2.1.0" targetFramework="xamarinios10" />
+  <package id="Acr.UserDialogs" version="6.5.1" targetFramework="xamarinios10" />
+  <package id="BTProgressHUD" version="1.2.0.5" targetFramework="xamarinios10" />
+  <package id="IdentityModel" version="3.0.0" targetFramework="xamarinios10" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="xamarinios10" />
+  <package id="PCLCrypto" version="2.0.147" targetFramework="xamarinios10" />
+  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="xamarinios10" />
+  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="xamarinios10" />
+  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="xamarinios10" />
+  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="xamarinios10" />
+  <package id="SlideOverKit" version="2.1.5" targetFramework="xamarinios10" />
+  <package id="Splat" version="2.0.0" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />
@@ -52,6 +63,11 @@
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="xamarinios10" />
+  <package id="Validation" version="2.2.8" targetFramework="xamarinios10" />
+  <package id="WebP.Touch" version="1.0.7" targetFramework="xamarinios10" />
+  <package id="Xam.Plugin.Geolocator" version="3.0.4" targetFramework="xamarinios10" />
+  <package id="Xamarin.FFImageLoading" version="2.3.4" targetFramework="xamarinios10" />
+  <package id="Xamarin.FFImageLoading.Forms" version="2.3.4" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.5.0.122203" targetFramework="xamarinios10" />
   <package id="xunit" version="2.3.1" targetFramework="xamarinios10" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="xamarinios10" />


### PR DESCRIPTION
Ever since `src/Mobile/eShopOnContainers/eShopOnContainers.Core/eShopOnContainers.csproj` was moved to .NETStandard (and SDK style .csproj), the eShopOnContainers.TestRunner.iOS.csproj hasn't been compiling in `Debug|iPhone` and `Release|iPhone` configurations. 

Turns out, with the .NETStandard core library, these target/head projects need these references as well to produce a successful build.