### PR TITLE
Changed how the MessageId is created.

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
@@ -46,7 +46,7 @@
 
             var message = new Message
             {
-                MessageId = new Guid().ToString(),
+                MessageId = Guid.NewGuid().ToString(),
                 Body = Encoding.UTF8.GetBytes(jsonMessage),
                 Label = eventName,
             };


### PR DESCRIPTION
This code change will resolve a duplication detection problem in Azure Service Bus.
Azure Service Bus uses the MessageId to dected if a message is a duplicate.
The current code always generates a Guid looking like this: "00000000-0000-0000-0000-000000000000".

This PR fixes the following issue: https://github.com/dotnet-architecture/eShopOnContainers/issues/508

Maby it's even better to set MessageId to 
`@event.MessageId.ToString()` ?