### PR TITLE
Removed duplicate string to byte conversion

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
@@ -47,7 +47,7 @@
             var message = new Message
             {
                 MessageId = Guid.NewGuid().ToString(),
-                Body = Encoding.UTF8.GetBytes(jsonMessage),
+                Body = body,
                 Label = eventName,
             };
 


### PR DESCRIPTION
The "Body" property now uses the already converted "body" variable.
Before, the "body" variable was not used at all.