### PR TITLE
Fix improper use of AddRangeAsync for seeding entities

### DIFF
--- a/src/Services/Identity/Identity.API/Data/ApplicationDbContextSeed.cs
+++ b/src/Services/Identity/Identity.API/Data/ApplicationDbContextSeed.cs
@@ -33,7 +33,7 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API.Data
 
                 if (!context.Users.Any())
                 {
-                    await context.Users.AddRangeAsync(useCustomizationData
+                    context.Users.AddRange(useCustomizationData
                         ? GetUsersFromFile(contentRootPath, logger)
                         : GetDefaultUser());
 

--- a/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
+++ b/src/Services/Identity/Identity.API/Data/ConfigurationDbContextSeed.cs
@@ -27,17 +27,17 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API.Data
 
             if (!await context.Clients.AnyAsync())
             {
-                await context.Clients.AddRangeAsync(Config.GetClients(clientUrls).Select(client => client.ToEntity()));
+                context.Clients.AddRange(Config.GetClients(clientUrls).Select(client => client.ToEntity()));
             }
 
             if (!await context.IdentityResources.AnyAsync())
             {
-                await context.IdentityResources.AddRangeAsync(Config.GetResources().Select(resource => resource.ToEntity()));
+                context.IdentityResources.AddRange(Config.GetResources().Select(resource => resource.ToEntity()));
             }
 
             if (!await context.ApiResources.AnyAsync())
             {
-                await context.ApiResources.AddRangeAsync(Config.GetApis().Select(api => api.ToEntity()));
+                context.ApiResources.AddRange(Config.GetApis().Select(api => api.ToEntity()));
             }
 
             await context.SaveChangesAsync();

--- a/src/Services/Ordering/Ordering.API/Infrastructure/OrderingContextSeed.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/OrderingContextSeed.cs
@@ -39,7 +39,7 @@
 
                     if (!context.CardTypes.Any())
                     {
-                        await context.CardTypes.AddRangeAsync(useCustomizationData
+                        context.CardTypes.AddRange(useCustomizationData
                                                 ? GetCardTypesFromFile(contentRootPath, logger)
                                                 : GetPredefinedCardTypes());
 
@@ -48,7 +48,7 @@
 
                     if (!context.OrderStatus.Any())
                     {
-                        await context.OrderStatus.AddRangeAsync(useCustomizationData
+                        context.OrderStatus.AddRange(useCustomizationData
                                                 ? GetOrderStatusFromFile(contentRootPath, logger)
                                                 : GetPredefinedOrderStatus());
                     }


### PR DESCRIPTION
that don't use the SequenceHiLo key generation strategy, as per https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbset-1.addrangeasync?view=efcore-2.0

As a result from an internal post-mortem review of PR #491 with @unaizorrilla, AddRangeAsync should only be used when entities use the SequenceHiLo key generation strategy, and that doesn't happen for the entities updated with this PR