### PR TITLE
Guards, more defensive VO and IDs

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/Address.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/Address.cs
@@ -1,26 +1,58 @@
-﻿using Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork;
+using Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork;
 using System;
 using System.Collections.Generic;
 
 namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.OrderAggregate
 {
-    public class Address : ValueObject
+    public sealed class Address : ValueObject
     {
-        public String Street { get; private set; }
-        public String City { get; private set; }
-        public String State { get; private set; }
-        public String Country { get; private set; }
-        public String ZipCode { get; private set; }
+        private String Street;
+        private String City;
+        private String State;
+        private String Country;
+        private String ZipCode;
 
-        private Address() { }
-
-        public Address(string street, string city, string state, string country, string zipcode)
+        public static Address fromString(String address) 
         {
-            Street = street;
-            City = city;
-            State = state;
-            Country = country;
-            ZipCode = zipcode;
+            Guards.AssertStringIsNotEmptyOrNull(address);
+            Guards.AssertStringLowerBound(address,5);
+
+            //Address toString() format with '_' between fields
+            string[] addressElements = address.Split('_');
+            Guards.AssertIsTrue(addressElements.Length == 5, "Invalid Address string format");
+
+            //toString() order
+            String Street = addressElements[0];
+            String ZipCode = addressElements[1];
+            String City = addressElements[2];
+            String State = addressElements[3];
+            String Country = addressElements[4];
+
+            return new Address(Street, ZipCode, City, State, Country);
+        }
+
+        public Address(string street, string zipcode, string city, string state, string country)
+        {
+            Guards.AssertStringIsNotEmptyOrNull(street);
+            Guards.AssertStringLowerBound(street,3);
+            this.Street = street;
+
+            Guards.AssertStringIsNotEmptyOrNull(zipcode);
+            Guards.AssertStringLowerBound(zipcode, 3);
+            this.ZipCode = zipcode;
+
+            Guards.AssertStringIsNotEmptyOrNull(city);
+            Guards.AssertStringLowerBound(city, 3);
+            this.City = city;
+
+            Guards.AssertStringIsNotEmptyOrNull(state);
+            Guards.AssertStringLowerBound(state, 3);
+            this.State = state;
+
+            Guards.AssertStringIsNotEmptyOrNull(country);
+            Guards.AssertStringLowerBound(country, 3);
+            this.Country = country;
+
         }
 
         protected override IEnumerable<object> GetAtomicValues()
@@ -32,5 +64,9 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.O
             yield return Country;
             yield return ZipCode;
         }
+
+        public override string ToString()
+        => $"{Street}_{ZipCode}_{City}_{State}_({Country})";
+
     }
 }

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Guards.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Guards.cs
@@ -1,0 +1,111 @@
+using System;
+
+namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
+{
+    public class Guards
+    {
+
+        private static int ArgumentCharCount(string argument) => string.IsNullOrEmpty(argument) ? 0 : argument.Trim().Length;
+
+        public static void AssertNotNull(Object arg1)
+        {
+            if (arg1 == null)
+            {
+                string message = "Argument Invalid, is null";
+                throw new ArgumentException(message);
+            }
+
+        }
+
+        public static void AssertGuidNotEmpty(Guid Id)
+        {
+            if (Id == Guid.Empty)
+            {
+                string message = $"Invalid GUID value. Set an ID not empty";
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        public static void AssertGuidsAreDifferent(Guid Id1, Guid Id2)
+        {
+            AssertGuidNotEmpty(Id1);
+            AssertGuidNotEmpty(Id2);
+            if (Id1 == Id2)
+            {
+                string message = $"Invalid request, the GUIDs are equal. Guid 1 {Id1} and Guid 2 {Id2}";
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        public static void AssertIntIsGreaterThan0(int number)
+        {
+            if (number < 0)
+            {
+                string message = $"Invalid int value. Set an interger greater than 0";
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertStringRange(string arg1, int upperBound, int lowerBound)
+        {
+            AssertNotNull(arg1);
+            if (ArgumentCharCount(arg1) > upperBound || ArgumentCharCount(arg1) < lowerBound)
+            {
+                string message = $"Invalid string range. Lower bound rule:{lowerBound} and Upper bound rule:{upperBound}. Whitespace borders are not allowed";
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertStringIsNotEmptyOrNull(string arg)
+        {
+            if (String.IsNullOrEmpty(arg))
+            {
+                string message = $"Invalid string value";
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertStringUpperBound(string arg1, int upperBound)
+        {
+            AssertNotNull(arg1);
+            if (ArgumentCharCount(arg1) > upperBound)
+            {
+                string message = $"Invalid string upper bound. Upper bound rule:{upperBound}. Whitespace borders are not allowed";
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertStringLowerBound(string arg1, int lowerBound)
+        {
+            AssertNotNull(arg1);
+            if (ArgumentCharCount(arg1) < lowerBound)
+            {
+                string message = $"Invalid string lower bound. Lower bound rule:{lowerBound}. Whitespace borders are not allowed";
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertIsFalse(bool flag, string message)
+        {
+            if (flag)
+            {
+                throw new InvalidOperationException(message);
+            }
+
+        }
+
+        public static void AssertIsTrue(bool flag,string message)
+        {
+            if (!flag)
+            {
+                throw new InvalidOperationException(message);
+            }
+
+        }
+    }
+}

--- a/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
+++ b/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
@@ -177,4 +177,32 @@ public class OrderAggregateTest
         //Assert
         Assert.Equal(fakeOrder.DomainEvents.Count, expectedResult);
     }
+    
+    
+    [Theory]
+    [InlineData(null,"87321","CityValue","StateValue","CountryValue")]
+    [InlineData("Street, 2 Int-3", "8", "CityValue", "StateValue", "CountryValue")]
+    [InlineData("Street, 34 ", "828394", "CityValue", "S", "CountryValue")]
+    [InlineData("Street,34", "12312", "CityValue", "State", "C")]
+    public void Create_Address_Throws(string street, string zipcode, string city, string state, string country)
+    {
+        Assert.Throws<InvalidOperationException>(()=> new Address(street,zipcode,city,state,country));
+    }
+
+    [Theory]
+    [InlineData("Street_82345_City_OnlyCountry")]
+    [InlineData("Street_82345_City_OnlyState")]
+    public void Create_AddressFromString_Throws(string address)
+    {
+        Assert.Throws<InvalidOperationException>(() => Address.fromString(address));
+    }
+
+    [Theory]
+    [InlineData("Street, 2_82345_City_State_Country")]
+    [InlineData("Street, 35_82345_City_State2_Country2")]
+    public void Create_AddressFromString_Success(string address)
+    {
+        Address copyAddressFromString = Address.fromString(address);
+        Assert.NotNull(copyAddressFromString);
+    }
 }


### PR DESCRIPTION
## Current Request - _DDD Model_

I create **Guards.cs** for adding some Assertion about _"general"_ correct state of an object in a specific moment. It's a good utility inside constructors and methods. You can change all _"base" if-checkers_ with something more _meaningful_. From my point of view, it's a more clear way to read model.
 
In Address Value Object, i try a more defensive approch with guards. I **remove getters** because i think we should add in future, if needed. I add a static constructor **_fromString_** that take an address string in input. 
Now, we may also discuss about: 
- correct string format in Address VO (see: Address toString() and inside static constructor fromString: { .... string[] addressElements = address.Split('_');  ... })
- What can be null in an address?
- Where the lower bounds are in each string field?

Leave  _private_  accessibility is a choice, in model design i love explicit things.

In OrderAggregateTest i write some simple _[Theory]_ with multiple input for checking Address VO guards and behaviour (static constructor).

This is a proposal to know what you think about. Do you think I have a **too much defensive** approach? 

## Possible future modification about _ids_  - _DDD Model_
We may add all **IDs** inside a Value Object. For example: PaymentMethodId _paymentId; BuyerId _buyerId;

I think it should be a good update for DDD project: 
1. **Guards** before assign the id (i know, i dream guards at night 😄 )
2. Less error prone. **Compiler can help us!** Assign an **int** has no meaning, it's an int. So if we assign a _paymentMethodId(int) inside a _buyerId(int), compiler says us "it's all ok guys!! 🎉 " ... 
3. We protect every piece of code that uses these Ids. The changes happen, with this approach we can change Id types without impact code.

Have a nice code day,
Enrico