### PR TITLE
Remove private setters to make class immutable

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/Events/OrderStartedDomainEvent.cs
+++ b/src/Services/Ordering/Ordering.Domain/Events/OrderStartedDomainEvent.cs
@@ -11,13 +11,13 @@ namespace Ordering.Domain.Events
     /// </summary>
     public class OrderStartedDomainEvent : INotification
     {
-        public string UserId { get; private set; }
-        public int CardTypeId { get; private set; }
-        public string CardNumber { get; private set; }
-        public string CardSecurityNumber { get; private set; }
-        public string CardHolderName { get; private set; }
-        public DateTime CardExpiration { get; private set; }
-        public Order Order { get; private set; }
+        public string UserId { get; }
+        public int CardTypeId { get; }
+        public string CardNumber { get; }
+        public string CardSecurityNumber { get; }
+        public string CardHolderName { get; }
+        public DateTime CardExpiration { get; }
+        public Order Order { get; }
 
         public OrderStartedDomainEvent(Order order, string userId,
                                        int cardTypeId, string cardNumber, 


### PR DESCRIPTION
Remove private setters to make a class truly immutable. Otherwise, properties can be updated outside of constructor. This also makes code cleaner. Same in docs https://github.com/dotnet/docs/pull/4755