### PR TITLE
Make Address value object truly immutable

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/Address.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/Address.cs
@@ -6,11 +6,11 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.O
 {
     public class Address : ValueObject
     {
-        public String Street { get; private set; }
-        public String City { get; private set; }
-        public String State { get; private set; }
-        public String Country { get; private set; }
-        public String ZipCode { get; private set; }
+        public String Street { get; }
+        public String City { get; }
+        public String State { get; }
+        public String Country { get; }
+        public String ZipCode { get; }
 
         private Address() { }
 


### PR DESCRIPTION
It's better to remove private property setters to make Address value object truly immutable. Otherwise, it's possible to change the object by setting properties inside its methods for example. Same in the docs dotnet/docs#4742

protected override IEnumerable<object> GetAtomicValues()
    {
       Street = "Blah blah blah";
       City = "Blah blah blah";

        // Using a yield return statement to return each element one at a time
        yield return Street;
        yield return City;
        yield return State;
        yield return Country;
        yield return ZipCode;
    }