### PR TITLE
Improved encapsulation of DomainEvents collection in Entity class

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Entity.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Entity.cs
@@ -21,17 +21,22 @@
         }
 
         private List<INotification> _domainEvents;
-        public List<INotification> DomainEvents => _domainEvents;       
-        
+        public IReadOnlyCollection<INotification> DomainEvents => _domainEvents?.AsReadOnly();
+
         public void AddDomainEvent(INotification eventItem)
         {
             _domainEvents = _domainEvents ?? new List<INotification>();
             _domainEvents.Add(eventItem);
         }
+
         public void RemoveDomainEvent(INotification eventItem)
         {
-            if (_domainEvents is null) return;
-            _domainEvents.Remove(eventItem);
+            _domainEvents?.Remove(eventItem);
+        }
+
+        public void ClearDomainEvents()
+        {
+            _domainEvents?.Clear();
         }
 
         public bool IsTransient()

--- a/src/Services/Ordering/Ordering.Infrastructure/MediatorExtension.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/MediatorExtension.cs
@@ -19,7 +19,7 @@ namespace Ordering.Infrastructure
                 .ToList();
 
             domainEntities.ToList()
-                .ForEach(entity => entity.Entity.DomainEvents.Clear());
+                .ForEach(entity => entity.Entity.ClearDomainEvents());
 
             var tasks = domainEvents
                 .Select(async (domainEvent) => {


### PR DESCRIPTION
This PR is a replacement for #556 

The Entity class should not expose the list of domain events as List<INotification>. This allows to modify the list of events without accessing Add/Remove methods. I propose to return IReadOnlyCollection<INotification> instead and add ClearDomainEvents() method to clear events. 