### PR TITLE
Urls for Identity, Gateway Shopping and Marketing added to setting view

### DIFF
--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/GlobalSettings.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/GlobalSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace eShopOnContainers.Core
+﻿using System;
+
+namespace eShopOnContainers.Core
 {
     public class GlobalSetting
     {
@@ -59,7 +61,7 @@
 
         public string RegisterWebsite { get; set; }
 
-        public string IdentityEndpoint { get; set; }
+        public string AuthorizeEndpoint { get; set; }
 
         public string UserInfoEndpoint { get; set; }
 
@@ -67,7 +69,7 @@
 
         public string LogoutEndpoint { get; set; }
 
-        public string IdentityCallback { get; set; }
+        public string Callback { get; set; }
 
         public string LogoutCallback { get; set; }
 
@@ -77,27 +79,35 @@
 
         private void UpdateEndpoint(string endpoint)
         {
-            var identityBaseEndpoint = $"{endpoint}/identity";
-            RegisterWebsite = $"{identityBaseEndpoint}/Account/Register";
-            LogoutCallback = $"{identityBaseEndpoint}/Account/Redirecting";
+            RegisterWebsite = $"{endpoint}/Account/Register";
+            LogoutCallback = $"{endpoint}/Account/Redirecting";
 
-            var connectBaseEndpoint = $"{identityBaseEndpoint}/connect";
-            IdentityEndpoint = $"{connectBaseEndpoint}/authorize";
+            var connectBaseEndpoint = $"{endpoint}/connect";
+            AuthorizeEndpoint = $"{connectBaseEndpoint}/authorize";
             UserInfoEndpoint = $"{connectBaseEndpoint}/userinfo";
             TokenEndpoint = $"{connectBaseEndpoint}/token";
             LogoutEndpoint = $"{connectBaseEndpoint}/endsession";
 
-            IdentityCallback = $"{endpoint}/xamarincallback";
+            var baseUri = ExtractBaseUri(endpoint);
+            Callback = $"{baseUri}/xamarincallback";
         }
 
         private void UpdateGatewayShoppingEndpoint(string endpoint)
         {
-            GatewayShoppingEndpoint = $"{endpoint}/mobileshoppingapigw";
+            GatewayShoppingEndpoint = $"{endpoint}";
         }
 
         private void UpdateGatewayMarketingEndpoint(string endpoint)
         {
-            GatewayMarketingEndpoint = $"{endpoint}/mobilemarketingapigw";
+            GatewayMarketingEndpoint = $"{endpoint}";
+        }
+
+        private string ExtractBaseUri(string endpoint)
+        {
+            var uri = new Uri(endpoint);
+            var baseUri = uri.GetLeftPart(System.UriPartial.Authority);
+
+            return baseUri;
         }
     }
 }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/GlobalSettings.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/GlobalSettings.cs
@@ -6,33 +6,54 @@
         public const string MockTag = "Mock";
         public const string DefaultEndpoint = "http://YOUR_IP_OR_DNS_NAME"; // i.e.: "http://YOUR_IP" or "http://YOUR_DNS_NAME"
 
-        private string _baseEndpoint;
-        private static readonly GlobalSetting _instance = new GlobalSetting();
+        private string _baseIdentityEndpoint;
+        private string _baseGatewayShoppingEndpoint;
+        private string _baseGatewayMarketingEndpoint;
 
         public GlobalSetting()
         {
             AuthToken = "INSERT AUTHENTICATION TOKEN";
-            BaseEndpoint = DefaultEndpoint;
+
+            BaseIdentityEndpoint = DefaultEndpoint;
+            BaseGatewayShoppingEndpoint = DefaultEndpoint;
+            BaseGatewayMarketingEndpoint = DefaultEndpoint;
         }
 
-        public static GlobalSetting Instance
-        {
-            get { return _instance; }
-        }
+        public static GlobalSetting Instance { get; } = new GlobalSetting();
 
-        public string BaseEndpoint
+        public string BaseIdentityEndpoint
         {
-            get { return _baseEndpoint; }
+            get { return _baseIdentityEndpoint; }
             set
             {
-                _baseEndpoint = value;
-                UpdateEndpoint(_baseEndpoint);
+                _baseIdentityEndpoint = value;
+                UpdateEndpoint(_baseIdentityEndpoint);
             }
         }
 
-        public string ClientId { get { return "xamarin"; }}
+        public string BaseGatewayShoppingEndpoint
+        {
+            get { return _baseGatewayShoppingEndpoint; }
+            set
+            {
+                _baseGatewayShoppingEndpoint = value;
+                UpdateGatewayShoppingEndpoint(_baseGatewayShoppingEndpoint);
+            }
+        }
 
-        public string ClientSecret { get { return "secret"; }}
+        public string BaseGatewayMarketingEndpoint
+        {
+            get { return _baseGatewayMarketingEndpoint; }
+            set
+            {
+                _baseGatewayMarketingEndpoint = value;
+                UpdateGatewayMarketingEndpoint(_baseGatewayMarketingEndpoint);
+            }
+        }
+
+        public string ClientId { get { return "xamarin"; } }
+
+        public string ClientSecret { get { return "secret"; } }
 
         public string AuthToken { get; set; }
 
@@ -50,9 +71,13 @@
 
         public string LogoutCallback { get; set; }
 
-        private void UpdateEndpoint(string baseEndpoint)
+        public string GatewayShoppingEndpoint { get; set; }
+
+        public string GatewayMarketingEndpoint { get; set; }
+
+        private void UpdateEndpoint(string endpoint)
         {
-            var identityBaseEndpoint = $"{baseEndpoint}/identity";
+            var identityBaseEndpoint = $"{endpoint}/identity";
             RegisterWebsite = $"{identityBaseEndpoint}/Account/Register";
             LogoutCallback = $"{identityBaseEndpoint}/Account/Redirecting";
 
@@ -61,8 +86,18 @@
             UserInfoEndpoint = $"{connectBaseEndpoint}/userinfo";
             TokenEndpoint = $"{connectBaseEndpoint}/token";
             LogoutEndpoint = $"{connectBaseEndpoint}/endsession";
-			
-            IdentityCallback = $"{baseEndpoint}/xamarincallback";
+
+            IdentityCallback = $"{endpoint}/xamarincallback";
+        }
+
+        private void UpdateGatewayShoppingEndpoint(string endpoint)
+        {
+            GatewayShoppingEndpoint = $"{endpoint}/mobileshoppingapigw";
+        }
+
+        private void UpdateGatewayMarketingEndpoint(string endpoint)
+        {
+            GatewayMarketingEndpoint = $"{endpoint}/mobilemarketingapigw";
         }
     }
 }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Helpers/UriHelper.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Helpers/UriHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace eShopOnContainers.Core.Helpers
+{
+    public static class UriHelper
+    {
+        public static string CombineUri(params string[] uriParts)
+        {
+            string uri = string.Empty;
+            if (uriParts != null && uriParts.Count() > 0)
+            {
+                char[] trims = new char[] { '\\', '/' };
+                uri = (uriParts[0] ?? string.Empty).TrimEnd(trims);
+                for (int i = 1; i < uriParts.Count(); i++)
+                {
+                    uri = string.Format("{0}/{1}", uri.TrimEnd(trims), (uriParts[i] ?? string.Empty).TrimStart(trims));
+                }
+            }
+            return uri;
+        }
+    }
+}

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Basket/BasketService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Basket/BasketService.cs
@@ -11,7 +11,7 @@ namespace eShopOnContainers.Core.Services.Basket
         private readonly IRequestProvider _requestProvider;
         private readonly IFixUriService _fixUriService;
 
-        private const string ApiUrlBase = "mobileshoppingapigw/api/v1/b/basket";
+        private const string ApiUrlBase = "api/v1/b/basket";
 
         public BasketService(IRequestProvider requestProvider, IFixUriService fixUriService)
         {
@@ -21,7 +21,7 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task<CustomerBasket> GetBasketAsync(string guidUser, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint)
+            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
             {
                 Path = $"{ApiUrlBase}/{guidUser}"
             };
@@ -45,7 +45,7 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task<CustomerBasket> UpdateBasketAsync(CustomerBasket customerBasket, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint)
+            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
             {
                 Path = ApiUrlBase
             };
@@ -57,7 +57,7 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task CheckoutAsync(BasketCheckout basketCheckout, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint)
+            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
             {
                 Path = $"{ApiUrlBase}/checkout"
             };
@@ -68,7 +68,7 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task ClearBasketAsync(string guidUser, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint)
+            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
             {
                 Path = $"{ApiUrlBase}/{guidUser}"
             };

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Basket/BasketService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Basket/BasketService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using eShopOnContainers.Core.Services.RequestProvider;
 using eShopOnContainers.Core.Models.Basket;
 using eShopOnContainers.Core.Services.FixUri;
+using eShopOnContainers.Core.Helpers;
 
 namespace eShopOnContainers.Core.Services.Basket
 {
@@ -21,12 +22,7 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task<CustomerBasket> GetBasketAsync(string guidUser, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
-            {
-                Path = $"{ApiUrlBase}/{guidUser}"
-            };
-
-            var uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/{guidUser}");
 
             CustomerBasket basket;
 
@@ -45,35 +41,23 @@ namespace eShopOnContainers.Core.Services.Basket
 
         public async Task<CustomerBasket> UpdateBasketAsync(CustomerBasket customerBasket, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
-            {
-                Path = ApiUrlBase
-            };
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, ApiUrlBase);
 
-            var uri = builder.ToString();
             var result = await _requestProvider.PostAsync(uri, customerBasket, token);
             return result;
         }
 
         public async Task CheckoutAsync(BasketCheckout basketCheckout, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
-            {
-                Path = $"{ApiUrlBase}/checkout"
-            };
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/checkout");
 
-            var uri = builder.ToString();
             await _requestProvider.PostAsync(uri, basketCheckout, token);
         }
 
         public async Task ClearBasketAsync(string guidUser, string token)
         {
-            var builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint)
-            {
-                Path = $"{ApiUrlBase}/{guidUser}"
-            };
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/{guidUser}");
 
-            var uri = builder.ToString();
             await _requestProvider.DeleteAsync(uri, token);
         }
     }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Catalog/CatalogService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Catalog/CatalogService.cs
@@ -6,6 +6,7 @@ using eShopOnContainers.Core.Services.RequestProvider;
 using eShopOnContainers.Core.Extensions;
 using System.Collections.Generic;
 using eShopOnContainers.Core.Services.FixUri;
+using eShopOnContainers.Core.Helpers;
 
 namespace eShopOnContainers.Core.Services.Catalog
 {
@@ -24,9 +25,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogItem>> FilterAsync(int catalogBrandId, int catalogTypeId)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-            builder.Path = $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}");
 
             CatalogRoot catalog = await _requestProvider.GetAsync<CatalogRoot>(uri);
 
@@ -38,9 +37,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogItem>> GetCatalogAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-            builder.Path = $"{ApiUrlBase}/items";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/items");
 
             CatalogRoot catalog = await _requestProvider.GetAsync<CatalogRoot>(uri);
 
@@ -55,9 +52,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogBrand>> GetCatalogBrandAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-            builder.Path = $"{ApiUrlBase}/catalogbrands";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/catalogbrands");
 
             IEnumerable<CatalogBrand> brands = await _requestProvider.GetAsync<IEnumerable<CatalogBrand>>(uri);
 
@@ -69,9 +64,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogType>> GetCatalogTypeAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-            builder.Path = $"{ApiUrlBase}/catalogtypes";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/catalogtypes");
 
             IEnumerable<CatalogType> types = await _requestProvider.GetAsync<IEnumerable<CatalogType>>(uri);
 

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Catalog/CatalogService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Catalog/CatalogService.cs
@@ -14,7 +14,7 @@ namespace eShopOnContainers.Core.Services.Catalog
         private readonly IRequestProvider _requestProvider;
         private readonly IFixUriService _fixUriService;
 		
-        private const string ApiUrlBase = "mobileshoppingapigw/api/v1/c/catalog";
+        private const string ApiUrlBase = "api/v1/c/catalog";
 
         public CatalogService(IRequestProvider requestProvider, IFixUriService fixUriService)
         {
@@ -24,7 +24,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogItem>> FilterAsync(int catalogBrandId, int catalogTypeId)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
             builder.Path = $"{ApiUrlBase}/items/type/{catalogTypeId}/brand/{catalogBrandId}";
             string uri = builder.ToString();
 
@@ -38,7 +38,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogItem>> GetCatalogAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
             builder.Path = $"{ApiUrlBase}/items";
             string uri = builder.ToString();
 
@@ -55,7 +55,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogBrand>> GetCatalogBrandAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
             builder.Path = $"{ApiUrlBase}/catalogbrands";
             string uri = builder.ToString();
 
@@ -69,7 +69,7 @@ namespace eShopOnContainers.Core.Services.Catalog
 
         public async Task<ObservableCollection<CatalogType>> GetCatalogTypeAsync()
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
             builder.Path = $"{ApiUrlBase}/catalogtypes";
             string uri = builder.ToString();
 

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/FixUri/FixUriService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/FixUri/FixUriService.cs
@@ -31,12 +31,12 @@ namespace eShopOnContainers.Core.Services.FixUri
             try
             {
                 if (!ViewModelLocator.UseMockService
-                    && _settingsService.UrlBase != GlobalSetting.DefaultEndpoint)
+                    && _settingsService.IdentityEndpointBase != GlobalSetting.DefaultEndpoint)
                 {
                     foreach (var catalogItem in catalogItems)
                     {
                         MatchCollection serverResult = IpRegex.Matches(catalogItem.PictureUri);
-                        MatchCollection localResult = IpRegex.Matches(_settingsService.UrlBase);
+                        MatchCollection localResult = IpRegex.Matches(_settingsService.IdentityEndpointBase);
 
                         if (serverResult.Count != -1 && localResult.Count != -1)
                         {
@@ -64,12 +64,12 @@ namespace eShopOnContainers.Core.Services.FixUri
             try
             {
                 if (!ViewModelLocator.UseMockService
-                    && _settingsService.UrlBase != GlobalSetting.DefaultEndpoint)
+                    && _settingsService.IdentityEndpointBase != GlobalSetting.DefaultEndpoint)
                 {
                     foreach (var basketItem in basketItems)
                     {
                         MatchCollection serverResult = IpRegex.Matches(basketItem.PictureUrl);
-                        MatchCollection localResult = IpRegex.Matches(_settingsService.UrlBase);
+                        MatchCollection localResult = IpRegex.Matches(_settingsService.IdentityEndpointBase);
 
                         if (serverResult.Count != -1 && localResult.Count != -1)
                         {
@@ -96,12 +96,12 @@ namespace eShopOnContainers.Core.Services.FixUri
             try
             {
                 if (!ViewModelLocator.UseMockService
-                    && _settingsService.UrlBase != GlobalSetting.DefaultEndpoint)
+                    && _settingsService.IdentityEndpointBase != GlobalSetting.DefaultEndpoint)
                 {
                     foreach (var campaignItem in campaignItems)
                     {
                         MatchCollection serverResult = IpRegex.Matches(campaignItem.PictureUri);
-                        MatchCollection localResult = IpRegex.Matches(_settingsService.UrlBase);
+                        MatchCollection localResult = IpRegex.Matches(_settingsService.IdentityEndpointBase);
 
                         if (serverResult.Count != -1 && localResult.Count != -1)
                         {

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Identity/IdentityService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Identity/IdentityService.cs
@@ -25,7 +25,7 @@ namespace eShopOnContainers.Core.Services.Identity
         public string CreateAuthorizationRequest()
         {
             // Create URI to authorization endpoint
-            var authorizeRequest = new AuthorizeRequest(GlobalSetting.Instance.IdentityEndpoint);
+            var authorizeRequest = new AuthorizeRequest(GlobalSetting.Instance.AuthorizeEndpoint);
 
             // Dictionary with values for the authorize request
             var dic = new Dictionary<string, string>();
@@ -33,7 +33,7 @@ namespace eShopOnContainers.Core.Services.Identity
             dic.Add("client_secret", GlobalSetting.Instance.ClientSecret);
             dic.Add("response_type", "code id_token");
             dic.Add("scope", "openid profile basket orders locations marketing offline_access");
-            dic.Add("redirect_uri", GlobalSetting.Instance.IdentityCallback);
+            dic.Add("redirect_uri", GlobalSetting.Instance.Callback);
             dic.Add("nonce", Guid.NewGuid().ToString("N"));
             dic.Add("code_challenge", CreateCodeChallenge());
             dic.Add("code_challenge_method", "S256");
@@ -61,7 +61,7 @@ namespace eShopOnContainers.Core.Services.Identity
 
         public async Task<UserToken> GetTokenAsync(string code)
         {
-            string data = string.Format("grant_type=authorization_code&code={0}&redirect_uri={1}&code_verifier={2}", code, WebUtility.UrlEncode(GlobalSetting.Instance.IdentityCallback), _codeVerifier);
+            string data = string.Format("grant_type=authorization_code&code={0}&redirect_uri={1}&code_verifier={2}", code, WebUtility.UrlEncode(GlobalSetting.Instance.Callback), _codeVerifier);
             var token = await _requestProvider.PostAsync<UserToken>(GlobalSetting.Instance.TokenEndpoint, data, GlobalSetting.Instance.ClientId, GlobalSetting.Instance.ClientSecret);
             return token;
         }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Location/LocationService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Location/LocationService.cs
@@ -8,6 +8,8 @@ namespace eShopOnContainers.Core.Services.Location
     {
         private readonly IRequestProvider _requestProvider;
 
+        private const string ApiUrlBase = "api/v1/l/locations";
+
         public LocationService(IRequestProvider requestProvider)
         {
             _requestProvider = requestProvider;
@@ -15,8 +17,8 @@ namespace eShopOnContainers.Core.Services.Location
 
         public async Task UpdateUserLocation(eShopOnContainers.Core.Models.Location.Location newLocReq, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
-            builder.Path = "/mobilemarketingapigw/api/v1/l/locations";
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
+            builder.Path = ApiUrlBase;
             string uri = builder.ToString();
             await _requestProvider.PostAsync(uri, newLocReq, token);
         }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Location/LocationService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Location/LocationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using eShopOnContainers.Core.Helpers;
 using eShopOnContainers.Core.Services.RequestProvider;
 
 namespace eShopOnContainers.Core.Services.Location
@@ -17,9 +18,8 @@ namespace eShopOnContainers.Core.Services.Location
 
         public async Task UpdateUserLocation(eShopOnContainers.Core.Models.Location.Location newLocReq, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
-            builder.Path = ApiUrlBase;
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayMarketingEndpoint, ApiUrlBase);
+
             await _requestProvider.PostAsync(uri, newLocReq, token);
         }
     }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Marketing/CampaignService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Marketing/CampaignService.cs
@@ -13,7 +13,7 @@ namespace eShopOnContainers.Core.Services.Marketing
         private readonly IRequestProvider _requestProvider;
         private readonly IFixUriService _fixUriService;
 
-        private const string ApiUrlBase = "mobilemarketingapigw/api/v1/m/campaigns";
+        private const string ApiUrlBase = "api/v1/m/campaigns";
 
         public CampaignService(IRequestProvider requestProvider, IFixUriService fixUriService)
         {
@@ -23,7 +23,7 @@ namespace eShopOnContainers.Core.Services.Marketing
 
         public async Task<ObservableCollection<CampaignItem>> GetAllCampaignsAsync(string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
             builder.Path = $"{ApiUrlBase}/user";
             string uri = builder.ToString();
 
@@ -40,7 +40,7 @@ namespace eShopOnContainers.Core.Services.Marketing
 
         public async Task<CampaignItem> GetCampaignByIdAsync(int campaignId, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
             builder.Path = $"{ApiUrlBase}/{campaignId}";
             string uri = builder.ToString();
             return await _requestProvider.GetAsync<CampaignItem>(uri, token);

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Marketing/CampaignService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Marketing/CampaignService.cs
@@ -1,4 +1,5 @@
 ﻿using eShopOnContainers.Core.Extensions;
+using eShopOnContainers.Core.Helpers;
 using eShopOnContainers.Core.Models.Marketing;
 using eShopOnContainers.Core.Services.FixUri;
 using eShopOnContainers.Core.Services.RequestProvider;
@@ -23,9 +24,7 @@ namespace eShopOnContainers.Core.Services.Marketing
 
         public async Task<ObservableCollection<CampaignItem>> GetAllCampaignsAsync(string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
-            builder.Path = $"{ApiUrlBase}/user";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayMarketingEndpoint, $"{ApiUrlBase}/user");
 
             CampaignRoot campaign = await _requestProvider.GetAsync<CampaignRoot>(uri, token);
 
@@ -40,9 +39,8 @@ namespace eShopOnContainers.Core.Services.Marketing
 
         public async Task<CampaignItem> GetCampaignByIdAsync(int campaignId, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayMarketingEndpoint);
-            builder.Path = $"{ApiUrlBase}/{campaignId}";
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayMarketingEndpoint, $"{ApiUrlBase}/{campaignId}");
+
             return await _requestProvider.GetAsync<CampaignItem>(uri, token);
         }
     }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Order/OrderService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Order/OrderService.cs
@@ -1,4 +1,5 @@
-﻿using eShopOnContainers.Core.Models.Basket;
+﻿using eShopOnContainers.Core.Helpers;
+using eShopOnContainers.Core.Models.Basket;
 using eShopOnContainers.Core.Models.Orders;
 using eShopOnContainers.Core.Services.RequestProvider;
 using System;
@@ -25,11 +26,7 @@ namespace eShopOnContainers.Core.Services.Order
 
         public async Task<ObservableCollection<Models.Orders.Order>> GetOrdersAsync(string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-
-            builder.Path = ApiUrlBase;
-
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, ApiUrlBase);
 
             ObservableCollection<Models.Orders.Order> orders =
                 await _requestProvider.GetAsync<ObservableCollection<Models.Orders.Order>>(uri, token);
@@ -42,11 +39,7 @@ namespace eShopOnContainers.Core.Services.Order
         {
             try
             {
-                UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-
-                builder.Path = $"{ApiUrlBase}/{orderId}";
-
-                string uri = builder.ToString();
+                var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/{orderId}");
 
                 Models.Orders.Order order =
                     await _requestProvider.GetAsync<Models.Orders.Order>(uri, token);
@@ -78,13 +71,10 @@ namespace eShopOnContainers.Core.Services.Order
 
         public async Task<bool> CancelOrderAsync(int orderId, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
-
-            builder.Path = $"{ApiUrlBase}/cancel";
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.GatewayShoppingEndpoint, $"{ApiUrlBase}/cancel");
 
             var cancelOrderCommand = new CancelOrderCommand(orderId);
 
-            string uri = builder.ToString();
             var header = "x-requestid";
 
             try

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Order/OrderService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Order/OrderService.cs
@@ -11,7 +11,7 @@ namespace eShopOnContainers.Core.Services.Order
     {
         private readonly IRequestProvider _requestProvider;
 
-        private const string ApiUrlBase = "mobileshoppingapigw/api/v1/o/orders";
+        private const string ApiUrlBase = "api/v1/o/orders";
 
         public OrderService(IRequestProvider requestProvider)
         {
@@ -25,7 +25,7 @@ namespace eShopOnContainers.Core.Services.Order
 
         public async Task<ObservableCollection<Models.Orders.Order>> GetOrdersAsync(string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
 
             builder.Path = ApiUrlBase;
 
@@ -42,7 +42,7 @@ namespace eShopOnContainers.Core.Services.Order
         {
             try
             {
-                UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+                UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
 
                 builder.Path = $"{ApiUrlBase}/{orderId}";
 
@@ -78,7 +78,7 @@ namespace eShopOnContainers.Core.Services.Order
 
         public async Task<bool> CancelOrderAsync(int orderId, string token)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.BaseEndpoint);
+            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.GatewayShoppingEndpoint);
 
             builder.Path = $"{ApiUrlBase}/cancel";
 

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Settings/ISettingsService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Settings/ISettingsService.cs
@@ -7,7 +7,9 @@ namespace eShopOnContainers.Core.Services.Settings
         string AuthAccessToken { get; set; }
         string AuthIdToken { get; set; }
         bool UseMocks { get; set; }
-        string UrlBase { get; set; }
+        string IdentityEndpointBase { get; set; }
+        string GatewayShoppingEndpointBase { get; set; }
+        string GatewayMarketingEndpointBase { get; set; }
         bool UseFakeLocation { get; set; }
         string Latitude { get; set; }
         string Longitude { get; set; }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Settings/SettingsService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/Settings/SettingsService.cs
@@ -11,7 +11,9 @@ namespace eShopOnContainers.Core.Services.Settings
         private const string AccessToken = "access_token";
         private const string IdToken = "id_token";
         private const string IdUseMocks = "use_mocks";
-        private const string IdUrlBase = "url_base";
+        private const string IdIdentityBase = "url_base";
+        private const string IdGatewayMarketingBase = "url_marketing";
+        private const string IdGatewayShoppingBase = "url_shopping";
         private const string IdUseFakeLocation = "use_fake_location";
         private const string IdLatitude = "latitude";
         private const string IdLongitude = "longitude";
@@ -23,8 +25,9 @@ namespace eShopOnContainers.Core.Services.Settings
         private readonly bool AllowGpsLocationDefault = false;
         private readonly double FakeLatitudeDefault = 47.604610d;
         private readonly double FakeLongitudeDefault = -122.315752d;
-        private readonly string UrlBaseDefault = GlobalSetting.Instance.BaseEndpoint;
-
+        private readonly string UrlIdentityDefault = GlobalSetting.Instance.BaseIdentityEndpoint;
+        private readonly string UrlGatewayMarketingDefault = GlobalSetting.Instance.BaseGatewayMarketingEndpoint;
+        private readonly string UrlGatewayShoppingDefault = GlobalSetting.Instance.BaseGatewayShoppingEndpoint;
         #endregion
 
         #region Settings Properties
@@ -47,10 +50,22 @@ namespace eShopOnContainers.Core.Services.Settings
             set => AddOrUpdateValue(IdUseMocks, value);
         }
 
-        public string UrlBase
+        public string IdentityEndpointBase
         {
-            get => GetValueOrDefault(IdUrlBase, UrlBaseDefault);
-            set => AddOrUpdateValue(IdUrlBase, value);
+            get => GetValueOrDefault(IdIdentityBase, UrlIdentityDefault);
+            set => AddOrUpdateValue(IdIdentityBase, value);
+        }
+
+        public string GatewayShoppingEndpointBase
+        {
+            get => GetValueOrDefault(IdGatewayShoppingBase, UrlGatewayShoppingDefault);
+            set => AddOrUpdateValue(IdGatewayShoppingBase, value);
+        }
+
+        public string GatewayMarketingEndpointBase
+        {
+            get => GetValueOrDefault(IdGatewayMarketingBase, UrlGatewayMarketingDefault);
+            set => AddOrUpdateValue(IdGatewayMarketingBase, value);
         }
 
         public bool UseFakeLocation

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/User/UserService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Services/User/UserService.cs
@@ -1,4 +1,5 @@
-﻿using eShopOnContainers.Core.Models.User;
+﻿using eShopOnContainers.Core.Helpers;
+using eShopOnContainers.Core.Models.User;
 using eShopOnContainers.Core.Services.RequestProvider;
 using System;
 using System.Threading.Tasks;
@@ -16,8 +17,8 @@ namespace eShopOnContainers.Core.Services.User
 
         public async Task<UserInfo> GetUserInfoAsync(string authToken)
         {
-            UriBuilder builder = new UriBuilder(GlobalSetting.Instance.UserInfoEndpoint);
-            string uri = builder.ToString();
+            var uri = UriHelper.CombineUri(GlobalSetting.Instance.UserInfoEndpoint);
+
             var userInfo = await _requestProvider.GetAsync<UserInfo>(uri, authToken);
             return userInfo;
         }

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/Base/ViewModelBase.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/Base/ViewModelBase.cs
@@ -29,7 +29,12 @@ namespace eShopOnContainers.Core.ViewModels.Base
         {
             DialogService = ViewModelLocator.Resolve<IDialogService>();
             NavigationService = ViewModelLocator.Resolve<INavigationService>();
-            GlobalSetting.Instance.BaseEndpoint = ViewModelLocator.Resolve<ISettingsService>().UrlBase;
+
+            var settingsService = ViewModelLocator.Resolve<ISettingsService>();
+
+            GlobalSetting.Instance.BaseIdentityEndpoint = settingsService.IdentityEndpointBase;
+            GlobalSetting.Instance.BaseGatewayShoppingEndpoint = settingsService.GatewayShoppingEndpointBase;
+            GlobalSetting.Instance.BaseGatewayMarketingEndpoint = settingsService.GatewayMarketingEndpointBase;
         }
 
         public virtual Task InitializeAsync(object navigationData)

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/LoginViewModel.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/LoginViewModel.cs
@@ -234,7 +234,7 @@ namespace eShopOnContainers.Core.ViewModels
                 IsLogin = false;
                 LoginUrl = _identityService.CreateAuthorizationRequest();
             }
-            else if (unescapedUrl.Contains(GlobalSetting.Instance.IdentityCallback))
+            else if (unescapedUrl.Contains(GlobalSetting.Instance.Callback))
             {
                 var authResponse = new AuthorizeResponse(url);
                 if (!string.IsNullOrWhiteSpace(authResponse.Code))

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/SettingsViewModel.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/ViewModels/SettingsViewModel.cs
@@ -16,7 +16,9 @@ namespace eShopOnContainers.Core.ViewModels
         private bool _useAzureServices;
         private bool _allowGpsLocation;
         private bool _useFakeLocation;
-        private string _endpoint;
+        private string _identityEndpoint;
+        private string _gatewayShoppingEndpoint;
+        private string _gatewayMarketingEndpoint;
         private double _latitude;
         private double _longitude;
         private string _gpsWarningMessage;
@@ -32,7 +34,9 @@ namespace eShopOnContainers.Core.ViewModels
             _dependencyService = dependencyService;
 
             _useAzureServices = !_settingsService.UseMocks;
-            _endpoint = _settingsService.UrlBase;
+            _identityEndpoint = _settingsService.IdentityEndpointBase;
+            _gatewayShoppingEndpoint = _settingsService.GatewayShoppingEndpointBase;
+            _gatewayMarketingEndpoint = _settingsService.GatewayMarketingEndpointBase;
             _latitude = double.Parse(_settingsService.Latitude, CultureInfo.CurrentCulture);
             _longitude = double.Parse(_settingsService.Longitude, CultureInfo.CurrentCulture);
             _useFakeLocation = _settingsService.UseFakeLocation;
@@ -51,7 +55,7 @@ namespace eShopOnContainers.Core.ViewModels
             {
                 return !UseAzureServices
                     ? "Mock Services are simulated objects that mimic the behavior of real services using a controlled approach."
-                        : "When enabling the use of microservices/containers, the app will attempt to use real services deployed as Docker containers at the specified base endpoint, which will must be reachable through the network.";
+                        : "When enabling the use of microservices/containers, the app will attempt to use real services deployed as Docker/Kubernetes containers at the specified base endpoint, which will must be reachable through the network.";
             }
         }
 
@@ -117,17 +121,45 @@ namespace eShopOnContainers.Core.ViewModels
             }
         }
 
-        public string Endpoint
+        public string IdentityEndpoint
         {
-            get => _endpoint;
+            get => _identityEndpoint;
             set
             {
-                _endpoint = value;
-                if (!string.IsNullOrEmpty(_endpoint))
+                _identityEndpoint = value;
+                if (!string.IsNullOrEmpty(_identityEndpoint))
                 {
-                    UpdateEndpoint();
+                    UpdateIdentityEndpoint();
                 }
-                RaisePropertyChanged(() => Endpoint);
+                RaisePropertyChanged(() => IdentityEndpoint);
+            }
+        }
+
+        public string GatewayShoppingEndpoint
+        {
+            get => _gatewayShoppingEndpoint;
+            set
+            {
+                _gatewayShoppingEndpoint = value;
+                if (!string.IsNullOrEmpty(_gatewayShoppingEndpoint))
+                {
+                    UpdateGatewayShoppingEndpoint();
+                }
+                RaisePropertyChanged(() => GatewayShoppingEndpoint);
+            }
+        }
+
+        public string GatewayMarketingEndpoint
+        {
+            get => _gatewayMarketingEndpoint;
+            set
+            {
+                _gatewayMarketingEndpoint = value;
+                if (!string.IsNullOrEmpty(_gatewayMarketingEndpoint))
+                {
+                    UpdateGatewayMarketingEndpoint();
+                }
+                RaisePropertyChanged(() => GatewayMarketingEndpoint);
             }
         }
 
@@ -233,10 +265,20 @@ namespace eShopOnContainers.Core.ViewModels
             _settingsService.UseMocks = !_useAzureServices;
         }
 
-        private void UpdateEndpoint()
+        private void UpdateIdentityEndpoint()
         {
             // Update remote endpoint (save to local storage)
-            GlobalSetting.Instance.BaseEndpoint = _settingsService.UrlBase = _endpoint;
+            GlobalSetting.Instance.BaseIdentityEndpoint = _settingsService.IdentityEndpointBase = _identityEndpoint;
+        }
+
+        private void UpdateGatewayShoppingEndpoint()
+        {
+            GlobalSetting.Instance.BaseGatewayShoppingEndpoint = _settingsService.GatewayShoppingEndpointBase = _gatewayShoppingEndpoint;
+        }
+
+        private void UpdateGatewayMarketingEndpoint()
+        {
+            GlobalSetting.Instance.BaseGatewayMarketingEndpoint = _settingsService.GatewayMarketingEndpointBase = _gatewayMarketingEndpoint;
         }
 
         private void UpdateFakeLocation()

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Views/SettingsView.xaml
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.Core/Views/SettingsView.xaml
@@ -168,10 +168,36 @@
             Style="{StaticResource SettingsStackLayoutStyle}"
             IsVisible="{Binding UseAzureServices}">
             <Label
-                Text="Endpoint"
+                Text="Identity Url"
                 Style="{StaticResource HeaderLabelStyle}"/>
             <Entry
-                Text="{Binding Endpoint, Mode=TwoWay}">
+                Text="{Binding IdentityEndpoint, Mode=TwoWay}">
+                <Entry.Style>
+                    <OnPlatform x:TypeArguments="Style">
+                        <On Platform="iOS, Android" Value="{StaticResource SettingsEntryStyle}" />
+                        <On Platform="UWP, WinRT, WinPhone" Value="{StaticResource SettingsUwpEntryStyle}" />
+                    </OnPlatform>
+                </Entry.Style>
+            </Entry>
+
+            <Label
+                Text="Gateway Shopping Url"
+                Style="{StaticResource HeaderLabelStyle}"/>
+            <Entry
+                Text="{Binding GatewayShoppingEndpoint, Mode=TwoWay}">
+                <Entry.Style>
+                    <OnPlatform x:TypeArguments="Style">
+                        <On Platform="iOS, Android" Value="{StaticResource SettingsEntryStyle}" />
+                        <On Platform="UWP, WinRT, WinPhone" Value="{StaticResource SettingsUwpEntryStyle}" />
+                    </OnPlatform>
+                </Entry.Style>
+            </Entry>
+
+            <Label
+                Text="Gateway Marketing Url"
+                Style="{StaticResource HeaderLabelStyle}"/>
+            <Entry
+                Text="{Binding GatewayMarketingEndpoint, Mode=TwoWay}">
                 <Entry.Style>
                     <OnPlatform x:TypeArguments="Style">
                         <On Platform="iOS, Android" Value="{StaticResource SettingsEntryStyle}" />

--- a/src/Mobile/eShopOnContainers/eShopOnContainers.UnitTests/Mocks/MockSettingsService.cs
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.UnitTests/Mocks/MockSettingsService.cs
@@ -11,7 +11,9 @@ namespace eShopOnContainers.UnitTests.Mocks
         const string AccessToken = "access_token";
         const string IdToken = "id_token";
         const string IdUseMocks = "use_mocks";
-        const string IdUrlBase = "url_base";
+        const string IdIdentityBase = "url_base";
+        const string IdGatewayMarketingBase = "url_marketing";
+        const string IdGatewayShoppingBase = "url_shopping";
         const string IdUseFakeLocation = "use_fake_location";
         const string IdLatitude = "latitude";
         const string IdLongitude = "longitude";
@@ -23,7 +25,9 @@ namespace eShopOnContainers.UnitTests.Mocks
         readonly bool AllowGpsLocationDefault = false;
         readonly double FakeLatitudeDefault = 47.604610d;
         readonly double FakeLongitudeDefault = -122.315752d;
-        readonly string UrlBaseDefault = "https://13.88.8.119";
+        readonly string UrlIdentityDefault = "https://13.88.8.119";
+        readonly string UrlGatewayMarketingDefault = "https://13.88.8.119";
+        readonly string UrlGatewayShoppingDefault = "https://13.88.8.119";
 
         public string AuthAccessToken
         {
@@ -43,10 +47,22 @@ namespace eShopOnContainers.UnitTests.Mocks
             set => AddOrUpdateValue(IdUseMocks, value);
         }
 
-        public string UrlBase
+        public string IdentityEndpointBase
         {
-            get => GetValueOrDefault(IdUrlBase, UrlBaseDefault);
-            set => AddOrUpdateValue(IdUrlBase, value);
+            get => GetValueOrDefault(IdIdentityBase, UrlIdentityDefault);
+            set => AddOrUpdateValue(IdIdentityBase, value);
+        }
+
+        public string GatewayShoppingEndpointBase
+        {
+            get => GetValueOrDefault(IdGatewayShoppingBase, UrlGatewayShoppingDefault);
+            set => AddOrUpdateValue(IdGatewayShoppingBase, value);
+        }
+
+        public string GatewayMarketingEndpointBase
+        {
+            get => GetValueOrDefault(IdGatewayMarketingBase, UrlGatewayMarketingDefault);
+            set => AddOrUpdateValue(IdGatewayMarketingBase, value);
         }
 
         public bool UseFakeLocation


### PR DESCRIPTION
This pull request introduce a separation in the urlbase setting entry to let the user set the url scheme needed in case of Docker or Kubernetes.
The setting menu now shows like this:

![capture](https://user-images.githubusercontent.com/577145/41847319-dcbf5d52-7879-11e8-8543-0ad13dfbf8a8.PNG)
