### PR TITLE
Modified Enumeration class to support private constructor

### DIFF
--- a/src/Services/Ordering/Ordering.API/Infrastructure/OrderingContextSeed.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/OrderingContextSeed.cs
@@ -1,12 +1,11 @@
 ﻿namespace Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure
 {
-    using AspNetCore.Builder;
     using global::Ordering.API.Extensions;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.BuyerAggregate;
     using Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.OrderAggregate;
-    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using Ordering.Infrastructure;
@@ -97,14 +96,9 @@
             return new CardType(id++, value.Trim('"').Trim());
         }
 
-        private  IEnumerable<CardType> GetPredefinedCardTypes()
+        private IEnumerable<CardType> GetPredefinedCardTypes()
         {
-            return new List<CardType>()
-            {
-                CardType.Amex,
-                CardType.Visa,
-                CardType.MasterCard
-            };
+            return Enumeration.GetAll<CardType>();
         }
 
         private IEnumerable<OrderStatus> GetOrderStatusFromFile(string contentRootPath, ILogger<OrderingContextSeed> log)

--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/CardType.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/CardType.cs
@@ -1,54 +1,39 @@
 ﻿using Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.BuyerAggregate
 {
-
+    /// <remarks> 
+    /// Card type class should be marked as abstract with protected constructor to encapsulate known enum types
+    /// this is currently not possible as OrderingContextSeed uses this constructor to load cardTypes from csv file
+    /// </remarks>
     public class CardType
         : Enumeration
     {
-        public static CardType Amex = new CardType(1, "Amex");
-        public static CardType Visa = new CardType(2, "Visa");
-        public static CardType MasterCard = new CardType(3, "MasterCard");
-
-        protected CardType() { }
+        public static CardType Amex = new AmexCardType();
+        public static CardType Visa = new VisaCardType();
+        public static CardType MasterCard = new MasterCardType();
 
         public CardType(int id, string name)
             : base(id, name)
         {
-
         }
 
-        public static IEnumerable<CardType> List()
+        private class AmexCardType : CardType
         {
-            return new[] { Amex, Visa, MasterCard };
+            public AmexCardType() : base(1, "Amex")
+            { }
         }
 
-        public static CardType FromName(string name)
+        private class VisaCardType : CardType
         {
-            var state = List()
-                .SingleOrDefault(s => String.Equals(s.Name, name, StringComparison.CurrentCultureIgnoreCase));
-
-            if (state == null)
-            {
-                throw new ArgumentException($"Possible values for CardType: {String.Join(",", List().Select(s => s.Name))}");
-            }
-
-            return state;
+            public VisaCardType() : base(2, "Visa")
+            { }
         }
 
-        public static CardType From(int id)
+        private class MasterCardType : CardType
         {
-            var state = List().SingleOrDefault(s => s.Id == id);
-
-            if (state == null)
-            {
-                throw new ArgumentException($"Possible values for CardType: {String.Join(",", List().Select(s => s.Name))}");
-            }
-
-            return state;
+            public MasterCardType() : base(3, "MasterCard")
+            { }
         }
     }
 }

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
@@ -62,7 +62,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             return matchingItem;
         }
 
-        private static T Parse<T, K>(K value, string description, Func<T, bool> predicate) where T : Enumeration, new()
+        private static T Parse<T, K>(K value, string description, Func<T, bool> predicate) where T : Enumeration
         {
             var matchingItem = GetAll<T>().FirstOrDefault(predicate);
 

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
@@ -11,7 +11,8 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
 
         public int Id { get; private set; }
 
-        protected Enumeration(){}
+        protected Enumeration()
+        { }
 
         protected Enumeration(int id, string name)
         {
@@ -21,19 +22,11 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
 
         public override string ToString() => Name;
 
-        public static IEnumerable<T> GetAll<T>() where T : Enumeration, new()
+        public static IEnumerable<T> GetAll<T>() where T : Enumeration
         {
-            var type = typeof(T);
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            var fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
-            foreach (var info in fields)
-            {
-                var instance = new T();
-                var locatedValue = info.GetValue(instance) as T;
-
-                if (locatedValue != null)
-                    yield return locatedValue;
-            }
+            return fields.Select(f => f.GetValue(null)).Cast<T>();
         }
 
         public override bool Equals(object obj)
@@ -57,13 +50,13 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             return absoluteDifference;
         }
 
-        public static T FromValue<T>(int value) where T : Enumeration, new()
+        public static T FromValue<T>(int value) where T : Enumeration
         {
             var matchingItem = Parse<T, int>(value, "value", item => item.Id == value);
             return matchingItem;
         }
 
-        public static T FromDisplayName<T>(string displayName) where T : Enumeration, new()
+        public static T FromDisplayName<T>(string displayName) where T : Enumeration
         {
             var matchingItem = Parse<T, string>(displayName, "display name", item => item.Name == displayName);
             return matchingItem;
@@ -79,6 +72,6 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             return matchingItem;
         }
 
-        public int CompareTo(object other) => Id.CompareTo(((Enumeration) other).Id);
+        public int CompareTo(object other) => Id.CompareTo(((Enumeration)other).Id);
     }
 }


### PR DESCRIPTION
Modified Enumeration class to support private constructor for Enum types + refactored orderingContextSeed to use GetAll() method to get predefined types.

This is the code change for #652 issue/refactor and also relates to the https://github.com/dotnet/docs/pull/6209.
