### PR TITLE
Fix classname of EventBus.Test models

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationEventHandler.cs
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationEventHandler.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace EventBus.Tests
 {
-    public class TestIntegrationOtherEventHandler : IIntegrationEventHandler<TestIntegrationEvent>
+    public class TestIntegrationEventHandler : IIntegrationEventHandler<TestIntegrationEvent>
     {
         public bool Handled { get; private set; }
 
-        public TestIntegrationOtherEventHandler()
+        public TestIntegrationEventHandler()
         {
             Handled = false;
         }

--- a/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationOtherEventHandler.cs
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationOtherEventHandler.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace EventBus.Tests
 {
-    public class TestIntegrationEventHandler : IIntegrationEventHandler<TestIntegrationEvent>
+    public class TestIntegrationOtherEventHandler : IIntegrationEventHandler<TestIntegrationEvent>
     {
         public bool Handled { get; private set; }
 
-        public TestIntegrationEventHandler()
+        public TestIntegrationOtherEventHandler()
         {
             Handled = false;
         }


### PR DESCRIPTION
Fix an inconsistency between filename and classname of EventBus.Test models.

The file `TestIntegrationOtherEventHandler.cs`  defines the class `TestIntegrationEventHandler `, and the file `TestIntegrationEventHandler .cs`  defines the class `TestIntegrationOtherEventHandler`.
