### PR TITLE
[enhancement] Update to ASP.NET Core 2.1.3

### DIFF
--- a/src/ApiGateways/ApiGw-Base/Dockerfile
+++ b/src/ApiGateways/ApiGw-Base/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY src/ApiGateways/ApiGw-Base/OcelotApiGw.csproj src/ApiGateways/ApiGw-Base/
 RUN dotnet restore src/ApiGateways/ApiGw-Base/

--- a/src/ApiGateways/ApiGw-Base/OcelotApiGw.csproj
+++ b/src/ApiGateways/ApiGw-Base/OcelotApiGw.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="wwwroot\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Ocelot" Version="3.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Ocelot" Version="3.0.0" />
+	</ItemGroup>
 </Project>

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/ApiGateways/Mobile.Bff.Shopping/aggregator

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Mobile.Shopping.HttpAggregator.csproj
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Mobile.Shopping.HttpAggregator.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyName>Mobile.Shopping.HttpAggregator</AssemblyName>
-    <RootNamespace>Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator</RootNamespace>
-    <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<AssemblyName>Mobile.Shopping.HttpAggregator</AssemblyName>
+		<RootNamespace>Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator</RootNamespace>
+		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="wwwroot\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/ApiGateways/Web.Bff.Shopping/aggregator

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Web.Shopping.HttpAggregator.csproj
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Web.Shopping.HttpAggregator.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyName>Web.Shopping.HttpAggregator</AssemblyName>
-    <RootNamespace>Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator</RootNamespace>
-    <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<AssemblyName>Web.Shopping.HttpAggregator</AssemblyName>
+		<RootNamespace>Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator</RootNamespace>
+		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="wwwroot\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="2.4.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBus</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBus</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.2" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Polly" Version="6.0.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac" Version="4.6.2" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+		<PackageReference Include="Polly" Version="6.1.0" />
+		<PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\EventBus\EventBus.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventBus\EventBus.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.2" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac" Version="4.6.2" />
+		<PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\EventBus\EventBus.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventBus\EventBus.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
+++ b/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>  
-  <ItemGroup>
-    <ProjectReference Include="..\EventBus\EventBus.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventBus\EventBus.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.AspNetCore.HealthChecks/Microsoft.AspNetCore.HealthChecks.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.AspNetCore.HealthChecks/Microsoft.AspNetCore.HealthChecks.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
@@ -1,26 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+		<PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+		<PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks/Microsoft.Extensions.HealthChecks.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\common\Guard.cs" Link="Internal\Guard.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+		<PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/WebHostCustomization/WebHost.Customization/WebHost.Customization.csproj
+++ b/src/BuildingBlocks/WebHostCustomization/WebHost.Customization/WebHost.Customization.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Polly" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Polly" Version="6.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -1,36 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Update="web.config">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Update="web.config">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Basket/Basket.API/Dockerfile
+++ b/src/Services/Basket/Basket.API/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.304-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Basket/Basket.API

--- a/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
+++ b/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
@@ -1,33 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="appsettings.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+		<PackageReference Include="Moq" Version="4.8.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\..\Location\Locations.API\Locations.API.csproj" />
-    <ProjectReference Include="..\Basket.API\Basket.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\..\Location\Locations.API\Locations.API.csproj" />
+		<ProjectReference Include="..\Basket.API\Basket.API.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
+++ b/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="MediatR" Version="4.1.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+		<PackageReference Include="MediatR" Version="4.1.0" />
+		<PackageReference Include="Moq" Version="4.8.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\Basket.API\Basket.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\Basket.API\Basket.API.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/src/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -35,13 +35,13 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
   </ItemGroup>

--- a/src/Services/Catalog/Catalog.API/Dockerfile
+++ b/src/Services/Catalog/Catalog.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Catalog/Catalog.API

--- a/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
+++ b/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
@@ -1,47 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-    <None Remove="Setup\CatalogBrands.csv" />
-    <None Remove="Setup\CatalogItems.csv" />
-    <None Remove="Setup\CatalogItems.zip" />
-    <None Remove="Setup\CatalogTypes.csv" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="appsettings.json" />
+		<None Remove="Setup\CatalogBrands.csv" />
+		<None Remove="Setup\CatalogItems.csv" />
+		<None Remove="Setup\CatalogItems.zip" />
+		<None Remove="Setup\CatalogTypes.csv" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogBrands.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogItems.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogItems.zip">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogTypes.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogBrands.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogItems.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogItems.zip">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogTypes.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
+++ b/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+		<PackageReference Include="Moq" Version="4.8.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\Catalog.API\Catalog.API.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Identity/Identity.API/Dockerfile
+++ b/src/Services/Identity/Identity.API/Dockerfile
@@ -1,9 +1,9 @@
 ARG NODE_IMAGE=node:8.11
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk as dotnet-build
+FROM microsoft/dotnet:2.1.401-sdk as dotnet-build
 WORKDIR /src
 
 FROM ${NODE_IMAGE} as node-build

--- a/src/Services/Identity/Identity.API/Identity.API.csproj
+++ b/src/Services/Identity/Identity.API/Identity.API.csproj
@@ -1,59 +1,60 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <UserSecretsId>aspnet-eShopOnContainers.Identity-90487118-103c-4ff0-b9da-e5e26f7ab0c5</UserSecretsId>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<UserSecretsId>aspnet-eShopOnContainers.Identity-90487118-103c-4ff0-b9da-e5e26f7ab0c5</UserSecretsId>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="Setup\**\*;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="Setup\**\*;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.1.0" />
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.3.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.1.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+	</ItemGroup>
 
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="dotnet bundle" Condition="'$(ASPNETCORE_ENVIRONMENT)'!='Development'" />
-  </Target>
+	<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+		<Exec Command="dotnet bundle" Condition="'$(ASPNETCORE_ENVIRONMENT)'!='Development'" />
+	</Target>
 
-  <ItemGroup>
-     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
-  </ItemGroup>
+	<ItemGroup>
+		<DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Certificate\idsrv3test.pfx" />
-  </ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="Certificate\idsrv3test.pfx" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="Setup\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="Setup\*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Extensions\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Extensions\" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Identity/Identity.API/Identity.API.csproj
+++ b/src/Services/Identity/Identity.API/Identity.API.csproj
@@ -33,10 +33,6 @@
 	</Target>
 
 	<ItemGroup>
-		<DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<EmbeddedResource Include="Certificate\idsrv3test.pfx" />
 	</ItemGroup>
 

--- a/src/Services/Location/Locations.API/Dockerfile
+++ b/src/Services/Location/Locations.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Location/Locations.API

--- a/src/Services/Location/Locations.API/Locations.API.csproj
+++ b/src/Services/Location/Locations.API/Locations.API.csproj
@@ -1,32 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <UserSecretsId>aspnet-Locations.API-20161122013619</UserSecretsId>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="mongocsharpdriver" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+		<UserSecretsId>aspnet-Locations.API-20161122013619</UserSecretsId>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+		<PackageReference Include="mongocsharpdriver" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Bson" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Driver" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Driver.Core" Version="2.5.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="2.4.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Location/Locations.FunctionalTests/Locations.FunctionalTests.csproj
+++ b/src/Services/Location/Locations.FunctionalTests/Locations.FunctionalTests.csproj
@@ -1,31 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="appsettings.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Locations.API\Locations.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Locations.API\Locations.API.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Marketing/Marketing.API/Dockerfile
+++ b/src/Services/Marketing/Marketing.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Marketing/Marketing.API

--- a/src/Services/Marketing/Marketing.API/Marketing.API.csproj
+++ b/src/Services/Marketing/Marketing.API/Marketing.API.csproj
@@ -1,55 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <RootNamespace>Microsoft.eShopOnContainers.Services.Marketing.API</RootNamespace>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-    <UserSecretsId>aspnet-Marketing.API-20161122013619</UserSecretsId>
-    <AssemblyName />
-    <ApplicationInsightsResourceId>/subscriptions/6c22bb55-0221-4ce4-9bf1-3c4a10a7294c/resourcegroups/eshop-log/providers/microsoft.insights/components/eshopappinsights</ApplicationInsightsResourceId>
-    <ApplicationInsightsAnnotationResourceId>/subscriptions/6c22bb55-0221-4ce4-9bf1-3c4a10a7294c/resourcegroups/eshop-log/providers/microsoft.insights/components/eshopappinsights</ApplicationInsightsAnnotationResourceId>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+		<RootNamespace>Microsoft.eShopOnContainers.Services.Marketing.API</RootNamespace>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<UserSecretsId>aspnet-Marketing.API-20161122013619</UserSecretsId>
+		<AssemblyName />
+		<ApplicationInsightsResourceId>/subscriptions/6c22bb55-0221-4ce4-9bf1-3c4a10a7294c/resourcegroups/eshop-log/providers/microsoft.insights/components/eshopappinsights</ApplicationInsightsResourceId>
+		<ApplicationInsightsAnnotationResourceId>/subscriptions/6c22bb55-0221-4ce4-9bf1-3c4a10a7294c/resourcegroups/eshop-log/providers/microsoft.insights/components/eshopappinsights</ApplicationInsightsAnnotationResourceId>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Connected Services\" />
-    <Folder Include="Infrastructure\MarketingMigrations\" />
-    <Content Include="Pics\**\*;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Folder Include="Infrastructure\MarketingMigrations\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="mongocsharpdriver" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Bson" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.AzureStorage\Microsoft.Extensions.HealthChecks.AzureStorage.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Connected Services\" />
+		<Folder Include="Infrastructure\MarketingMigrations\" />
+		<Content Include="Pics\**\*;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Folder Include="Infrastructure\MarketingMigrations\" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="mongocsharpdriver" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Bson" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Driver" Version="2.5.0" />
+		<PackageReference Include="MongoDB.Driver.Core" Version="2.5.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.AzureStorage\Microsoft.Extensions.HealthChecks.AzureStorage.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="Pics\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="Pics\*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services" />
-  </ItemGroup>
+	<ItemGroup>
+		<WCFMetadata Include="Connected Services" />
+	</ItemGroup>
 </Project>

--- a/src/Services/Marketing/Marketing.FunctionalTests/Marketing.FunctionalTests.csproj
+++ b/src/Services/Marketing/Marketing.FunctionalTests/Marketing.FunctionalTests.csproj
@@ -1,32 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="appsettings.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\Marketing.API\Marketing.API.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\Marketing.API\Marketing.API.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.API/Dockerfile
+++ b/src/Services/Ordering/Ordering.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Ordering/Ordering.API

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -1,56 +1,57 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <UserSecretsId>aspnet-Ordering.API-20161122013547</UserSecretsId>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<UserSecretsId>aspnet-Ordering.API-20161122013547</UserSecretsId>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Update="web.config;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Include="Setup\**\*;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Update="web.config;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Include="Setup\**\*;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\IntegrationEventLogEF\IntegrationEventLogEF.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
-    <ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
-    <ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\IntegrationEventLogEF\IntegrationEventLogEF.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\WebHostCustomization\WebHost.Customization\WebHost.Customization.csproj" />
+		<ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
+		<ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="MediatR" Version="4.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="Dapper" Version="1.50.4" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Polly" Version="6.0.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Setup\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Dapper" Version="1.50.4" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="7.5.0" />
+		<PackageReference Include="MediatR" Version="4.1.0" />
+		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="4.1.0" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="Polly" Version="6.1.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+		<PackageReference Include="System.Reflection" Version="4.3.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="Setup\*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Ordering/Ordering.BackgroundTasks

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Ordering.BackgroundTasks.csproj
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Ordering.BackgroundTasks.csproj
@@ -1,31 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="wwwroot\**" />
-    <Content Remove="wwwroot\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
-    <None Remove="wwwroot\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="wwwroot\**" />
+		<Content Remove="wwwroot\**" />
+		<EmbeddedResource Remove="wwwroot\**" />
+		<None Remove="wwwroot\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Dapper" Version="1.50.4" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Dapper" Version="1.50.4" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -1,34 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="appsettings.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\Ordering.API\Ordering.API.csproj" />
-    <ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
-    <ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\Ordering.API\Ordering.API.csproj" />
+		<ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
+		<ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
+++ b/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Properties\" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Ordering/Ordering.SignalrHub

--- a/src/Services/Ordering/Ordering.SignalrHub/Ordering.SignalrHub.csproj
+++ b/src/Services/Ordering/Ordering.SignalrHub/Ordering.SignalrHub.csproj
@@ -1,31 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="wwwroot\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Redis" Version="1.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Redis" Version="1.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
+++ b/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="MediatR" Version="4.1.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+		<PackageReference Include="MediatR" Version="4.1.0" />
+		<PackageReference Include="Moq" Version="4.8.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
-    <ProjectReference Include="..\Ordering.API\Ordering.API.csproj" />
-    <ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
-    <ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Web\WebMVC\WebMVC.csproj" />
+		<ProjectReference Include="..\Ordering.API\Ordering.API.csproj" />
+		<ProjectReference Include="..\Ordering.Domain\Ordering.Domain.csproj" />
+		<ProjectReference Include="..\Ordering.Infrastructure\Ordering.Infrastructure.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Services/Payment/Payment.API/Dockerfile
+++ b/src/Services/Payment/Payment.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Services/Payment/Payment.API

--- a/src/Services/Payment/Payment.API/Payment.API.csproj
+++ b/src/Services/Payment/Payment.API/Payment.API.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\IntegrationEventLogEF\IntegrationEventLogEF.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
-    <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusServiceBus\EventBusServiceBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\EventBus\IntegrationEventLogEF\IntegrationEventLogEF.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.SqlServer\Microsoft.Extensions.HealthChecks.SqlServer.csproj" />
+		<ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Web/WebMVC/Dockerfile
+++ b/src/Web/WebMVC/Dockerfile
@@ -1,9 +1,9 @@
 ARG NODE_IMAGE=node:8.11
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk as dotnet-build
+FROM microsoft/dotnet:2.1.401-sdk as dotnet-build
 WORKDIR /src
 
 FROM ${NODE_IMAGE} as node-build

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -1,51 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <UserSecretsId>aspnet-Microsoft.eShopOnContainers-946ae052-8305-4a99-965b-ec8636ddbae3</UserSecretsId>
-    <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<UserSecretsId>aspnet-Microsoft.eShopOnContainers-946ae052-8305-4a99-965b-ec8636ddbae3</UserSecretsId>
+		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="Setup\images.zip">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\override.css">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="Setup\images.zip">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\override.css">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="2.6.375" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.3.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Fabric.MSBuild" Version="1.6.5" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BuildBundlerMinifier" Version="2.6.375" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Fabric.MSBuild" Version="1.6.5" />
+	</ItemGroup>
 
-  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="dotnet bundle" Condition="'$(ASPNETCORE_ENVIRONMENT)'!='Development'" />
-  </Target>
+	<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+		<Exec Command="dotnet bundle" Condition="'$(ASPNETCORE_ENVIRONMENT)'!='Development'" />
+	</Target>
 
-  <ItemGroup>
-     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
-  </ItemGroup>
+	<ItemGroup>
+		<DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="ViewModels\CampaignItem.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="ViewModels\CampaignItem.cs" />
+	</ItemGroup>
 
 </Project>

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -36,11 +36,6 @@
 	</Target>
 
 	<ItemGroup>
-		<DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.7.385" />
-	</ItemGroup>
-
-
-	<ItemGroup>
 		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
 		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
 	</ItemGroup>

--- a/src/Web/WebSPA/Dockerfile
+++ b/src/Web/WebSPA/Dockerfile
@@ -1,9 +1,9 @@
 ARG NODE_IMAGE=node:8.11
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk as dotnet-build
+FROM microsoft/dotnet:2.1.401-sdk as dotnet-build
 WORKDIR /src
 
 FROM ${NODE_IMAGE} as node-build

--- a/src/Web/WebSPA/WebSPA.csproj
+++ b/src/Web/WebSPA/WebSPA.csproj
@@ -1,102 +1,103 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <UserSecretsId>aspnetcorespa-c23d27a4-eb88-4b18-9b77-2a93f3b15119</UserSecretsId>
-    <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <TypeScriptCompileOnSaveEnabled>false</TypeScriptCompileOnSaveEnabled>
-    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <GeneratedItemPatterns>wwwroot/dist/**</GeneratedItemPatterns>
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(GeneratedItemPatterns)</DefaultItemExcludes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<UserSecretsId>aspnetcorespa-c23d27a4-eb88-4b18-9b77-2a93f3b15119</UserSecretsId>
+		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+		<TypeScriptCompileOnSaveEnabled>false</TypeScriptCompileOnSaveEnabled>
+		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+		<GeneratedItemPatterns>wwwroot/dist/**</GeneratedItemPatterns>
+		<DefaultItemExcludes>$(DefaultItemExcludes);$(GeneratedItemPatterns)</DefaultItemExcludes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="node_modules\**\*;Client\**\*" />
-    <None Remove="Client\environments\environment.prod.ts" />
-    <None Remove="Client\environments\environment.ts" />
-    <None Remove="Client\guid.ts" />
-    <None Remove="Client\main.ts" />
-    <None Remove="Client\modules\app.component.ts" />
-    <None Remove="Client\modules\app.module.ts" />
-    <None Remove="Client\modules\app.routes.ts" />
-    <None Remove="Client\modules\app.service.ts" />
-    <None Remove="Client\modules\basket\basket-status\basket-status.component.ts" />
-    <None Remove="Client\modules\basket\basket.component.ts" />
-    <None Remove="Client\modules\basket\basket.module.ts" />
-    <None Remove="Client\modules\basket\basket.service.ts" />
-    <None Remove="Client\modules\campaigns\campaigns-detail\campaigns-detail.component.ts" />
-    <None Remove="Client\modules\campaigns\campaigns.component.ts" />
-    <None Remove="Client\modules\campaigns\campaigns.module.ts" />
-    <None Remove="Client\modules\campaigns\campaigns.service.ts" />
-    <None Remove="Client\modules\catalog\catalog.component.ts" />
-    <None Remove="Client\modules\catalog\catalog.module.ts" />
-    <None Remove="Client\modules\catalog\catalog.service.ts" />
-    <None Remove="Client\modules\orders\orders-detail\orders-detail.component.ts" />
-    <None Remove="Client\modules\orders\orders-new\orders-new.component.ts" />
-    <None Remove="Client\modules\orders\orders.component.ts" />
-    <None Remove="Client\modules\orders\orders.module.ts" />
-    <None Remove="Client\modules\orders\orders.service.ts" />
-    <None Remove="Client\modules\shared\components\header\header.ts" />
-    <None Remove="Client\modules\shared\components\identity\identity.ts" />
-    <None Remove="Client\modules\shared\components\page-not-found\page-not-found.component.spec.ts" />
-    <None Remove="Client\modules\shared\components\page-not-found\page-not-found.component.ts" />
-    <None Remove="Client\modules\shared\components\pager\pager.ts" />
-    <None Remove="Client\modules\shared\models\basket.model.ts" />
-    <None Remove="Client\modules\shared\models\basketCheckout.model.ts" />
-    <None Remove="Client\modules\shared\models\basketItem.model.ts" />
-    <None Remove="Client\modules\shared\models\campaign.model.ts" />
-    <None Remove="Client\modules\shared\models\campaignItem.model.ts" />
-    <None Remove="Client\modules\shared\models\catalog.model.ts" />
-    <None Remove="Client\modules\shared\models\catalogBrand.model.ts" />
-    <None Remove="Client\modules\shared\models\catalogItem.model.ts" />
-    <None Remove="Client\modules\shared\models\catalogType.model.ts" />
-    <None Remove="Client\modules\shared\models\configuration.model.ts" />
-    <None Remove="Client\modules\shared\models\identity.model.ts" />
-    <None Remove="Client\modules\shared\models\order-detail.model.ts" />
-    <None Remove="Client\modules\shared\models\order.model.ts" />
-    <None Remove="Client\modules\shared\models\orderItem.model.ts" />
-    <None Remove="Client\modules\shared\models\pager.model.ts" />
-    <None Remove="Client\modules\shared\pipes\uppercase.pipe.spec.ts" />
-    <None Remove="Client\modules\shared\pipes\uppercase.pipe.ts" />
-    <None Remove="Client\modules\shared\services\basket.wrapper.service.ts" />
-    <None Remove="Client\modules\shared\services\configuration.service.ts" />
-    <None Remove="Client\modules\shared\services\data.service.ts" />
-    <None Remove="Client\modules\shared\services\notification.service.ts" />
-    <None Remove="Client\modules\shared\services\security.service.ts" />
-    <None Remove="Client\modules\shared\services\signalr.service.ts" />
-    <None Remove="Client\modules\shared\services\storage.service.ts" />
-    <None Remove="Client\modules\shared\shared.module.ts" />
-    <None Remove="Client\polyfills.ts" />
-    <None Remove="Client\test.ts" />
-    <None Remove="Client\typings.d.ts" />
-    <Content Include="Setup\images.zip">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="appsettings.json;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="web.config;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Update="wwwroot\**\*;">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="node_modules\**\*;Client\**\*" />
+		<None Remove="Client\environments\environment.prod.ts" />
+		<None Remove="Client\environments\environment.ts" />
+		<None Remove="Client\guid.ts" />
+		<None Remove="Client\main.ts" />
+		<None Remove="Client\modules\app.component.ts" />
+		<None Remove="Client\modules\app.module.ts" />
+		<None Remove="Client\modules\app.routes.ts" />
+		<None Remove="Client\modules\app.service.ts" />
+		<None Remove="Client\modules\basket\basket-status\basket-status.component.ts" />
+		<None Remove="Client\modules\basket\basket.component.ts" />
+		<None Remove="Client\modules\basket\basket.module.ts" />
+		<None Remove="Client\modules\basket\basket.service.ts" />
+		<None Remove="Client\modules\campaigns\campaigns-detail\campaigns-detail.component.ts" />
+		<None Remove="Client\modules\campaigns\campaigns.component.ts" />
+		<None Remove="Client\modules\campaigns\campaigns.module.ts" />
+		<None Remove="Client\modules\campaigns\campaigns.service.ts" />
+		<None Remove="Client\modules\catalog\catalog.component.ts" />
+		<None Remove="Client\modules\catalog\catalog.module.ts" />
+		<None Remove="Client\modules\catalog\catalog.service.ts" />
+		<None Remove="Client\modules\orders\orders-detail\orders-detail.component.ts" />
+		<None Remove="Client\modules\orders\orders-new\orders-new.component.ts" />
+		<None Remove="Client\modules\orders\orders.component.ts" />
+		<None Remove="Client\modules\orders\orders.module.ts" />
+		<None Remove="Client\modules\orders\orders.service.ts" />
+		<None Remove="Client\modules\shared\components\header\header.ts" />
+		<None Remove="Client\modules\shared\components\identity\identity.ts" />
+		<None Remove="Client\modules\shared\components\page-not-found\page-not-found.component.spec.ts" />
+		<None Remove="Client\modules\shared\components\page-not-found\page-not-found.component.ts" />
+		<None Remove="Client\modules\shared\components\pager\pager.ts" />
+		<None Remove="Client\modules\shared\models\basket.model.ts" />
+		<None Remove="Client\modules\shared\models\basketCheckout.model.ts" />
+		<None Remove="Client\modules\shared\models\basketItem.model.ts" />
+		<None Remove="Client\modules\shared\models\campaign.model.ts" />
+		<None Remove="Client\modules\shared\models\campaignItem.model.ts" />
+		<None Remove="Client\modules\shared\models\catalog.model.ts" />
+		<None Remove="Client\modules\shared\models\catalogBrand.model.ts" />
+		<None Remove="Client\modules\shared\models\catalogItem.model.ts" />
+		<None Remove="Client\modules\shared\models\catalogType.model.ts" />
+		<None Remove="Client\modules\shared\models\configuration.model.ts" />
+		<None Remove="Client\modules\shared\models\identity.model.ts" />
+		<None Remove="Client\modules\shared\models\order-detail.model.ts" />
+		<None Remove="Client\modules\shared\models\order.model.ts" />
+		<None Remove="Client\modules\shared\models\orderItem.model.ts" />
+		<None Remove="Client\modules\shared\models\pager.model.ts" />
+		<None Remove="Client\modules\shared\pipes\uppercase.pipe.spec.ts" />
+		<None Remove="Client\modules\shared\pipes\uppercase.pipe.ts" />
+		<None Remove="Client\modules\shared\services\basket.wrapper.service.ts" />
+		<None Remove="Client\modules\shared\services\configuration.service.ts" />
+		<None Remove="Client\modules\shared\services\data.service.ts" />
+		<None Remove="Client\modules\shared\services\notification.service.ts" />
+		<None Remove="Client\modules\shared\services\security.service.ts" />
+		<None Remove="Client\modules\shared\services\signalr.service.ts" />
+		<None Remove="Client\modules\shared\services\storage.service.ts" />
+		<None Remove="Client\modules\shared\shared.module.ts" />
+		<None Remove="Client\polyfills.ts" />
+		<None Remove="Client\test.ts" />
+		<None Remove="Client\typings.d.ts" />
+		<Content Include="Setup\images.zip">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Update="appsettings.json;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Update="web.config;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Update="wwwroot\**\*;">
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.3.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+	</ItemGroup>
 
 
-  <!-- workaround for https://github.com/aspnet/websdk/issues/114 -->
-  <!--
+	<!-- workaround for https://github.com/aspnet/websdk/issues/114 -->
+	<!--
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">
       <ItemGroup>
           <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
@@ -104,79 +105,79 @@
   </Target>
   -->
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\assets\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="wwwroot\assets\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <TypeScriptCompile Include="Client\environments\environment.prod.ts" />
-    <TypeScriptCompile Include="Client\environments\environment.ts" />
-    <TypeScriptCompile Include="Client\guid.ts" />
-    <TypeScriptCompile Include="Client\main.ts" />
-    <TypeScriptCompile Include="Client\modules\app.component.ts" />
-    <TypeScriptCompile Include="Client\modules\app.module.ts" />
-    <TypeScriptCompile Include="Client\modules\app.routes.ts" />
-    <TypeScriptCompile Include="Client\modules\app.service.ts" />
-    <TypeScriptCompile Include="Client\modules\basket\basket-status\basket-status.component.ts" />
-    <TypeScriptCompile Include="Client\modules\basket\basket.component.ts" />
-    <TypeScriptCompile Include="Client\modules\basket\basket.module.ts" />
-    <TypeScriptCompile Include="Client\modules\basket\basket.service.ts" />
-    <TypeScriptCompile Include="Client\modules\campaigns\campaigns-detail\campaigns-detail.component.ts" />
-    <TypeScriptCompile Include="Client\modules\campaigns\campaigns.component.ts" />
-    <TypeScriptCompile Include="Client\modules\campaigns\campaigns.module.ts" />
-    <TypeScriptCompile Include="Client\modules\campaigns\campaigns.service.ts" />
-    <TypeScriptCompile Include="Client\modules\catalog\catalog.component.ts" />
-    <TypeScriptCompile Include="Client\modules\catalog\catalog.module.ts" />
-    <TypeScriptCompile Include="Client\modules\catalog\catalog.service.ts" />
-    <TypeScriptCompile Include="Client\modules\orders\orders-detail\orders-detail.component.ts" />
-    <TypeScriptCompile Include="Client\modules\orders\orders-new\orders-new.component.ts" />
-    <TypeScriptCompile Include="Client\modules\orders\orders.component.ts" />
-    <TypeScriptCompile Include="Client\modules\orders\orders.module.ts" />
-    <TypeScriptCompile Include="Client\modules\orders\orders.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\components\header\header.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\components\identity\identity.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\components\page-not-found\page-not-found.component.spec.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\components\page-not-found\page-not-found.component.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\components\pager\pager.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\basket.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\basketCheckout.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\basketItem.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\campaign.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\campaignItem.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\catalog.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\catalogBrand.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\catalogItem.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\catalogType.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\configuration.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\identity.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\order-detail.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\order.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\orderItem.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\models\pager.model.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\pipes\uppercase.pipe.spec.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\pipes\uppercase.pipe.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\basket.wrapper.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\configuration.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\data.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\notification.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\security.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\signalr.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\services\storage.service.ts" />
-    <TypeScriptCompile Include="Client\modules\shared\shared.module.ts" />
-    <TypeScriptCompile Include="Client\polyfills.ts" />
-    <TypeScriptCompile Include="Client\test.ts" />
-    <TypeScriptCompile Include="Client\typings.d.ts" />
-  </ItemGroup>
+	<ItemGroup>
+		<TypeScriptCompile Include="Client\environments\environment.prod.ts" />
+		<TypeScriptCompile Include="Client\environments\environment.ts" />
+		<TypeScriptCompile Include="Client\guid.ts" />
+		<TypeScriptCompile Include="Client\main.ts" />
+		<TypeScriptCompile Include="Client\modules\app.component.ts" />
+		<TypeScriptCompile Include="Client\modules\app.module.ts" />
+		<TypeScriptCompile Include="Client\modules\app.routes.ts" />
+		<TypeScriptCompile Include="Client\modules\app.service.ts" />
+		<TypeScriptCompile Include="Client\modules\basket\basket-status\basket-status.component.ts" />
+		<TypeScriptCompile Include="Client\modules\basket\basket.component.ts" />
+		<TypeScriptCompile Include="Client\modules\basket\basket.module.ts" />
+		<TypeScriptCompile Include="Client\modules\basket\basket.service.ts" />
+		<TypeScriptCompile Include="Client\modules\campaigns\campaigns-detail\campaigns-detail.component.ts" />
+		<TypeScriptCompile Include="Client\modules\campaigns\campaigns.component.ts" />
+		<TypeScriptCompile Include="Client\modules\campaigns\campaigns.module.ts" />
+		<TypeScriptCompile Include="Client\modules\campaigns\campaigns.service.ts" />
+		<TypeScriptCompile Include="Client\modules\catalog\catalog.component.ts" />
+		<TypeScriptCompile Include="Client\modules\catalog\catalog.module.ts" />
+		<TypeScriptCompile Include="Client\modules\catalog\catalog.service.ts" />
+		<TypeScriptCompile Include="Client\modules\orders\orders-detail\orders-detail.component.ts" />
+		<TypeScriptCompile Include="Client\modules\orders\orders-new\orders-new.component.ts" />
+		<TypeScriptCompile Include="Client\modules\orders\orders.component.ts" />
+		<TypeScriptCompile Include="Client\modules\orders\orders.module.ts" />
+		<TypeScriptCompile Include="Client\modules\orders\orders.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\components\header\header.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\components\identity\identity.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\components\page-not-found\page-not-found.component.spec.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\components\page-not-found\page-not-found.component.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\components\pager\pager.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\basket.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\basketCheckout.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\basketItem.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\campaign.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\campaignItem.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\catalog.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\catalogBrand.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\catalogItem.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\catalogType.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\configuration.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\identity.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\order-detail.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\order.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\orderItem.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\models\pager.model.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\pipes\uppercase.pipe.spec.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\pipes\uppercase.pipe.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\basket.wrapper.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\configuration.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\data.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\notification.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\security.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\signalr.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\services\storage.service.ts" />
+		<TypeScriptCompile Include="Client\modules\shared\shared.module.ts" />
+		<TypeScriptCompile Include="Client\polyfills.ts" />
+		<TypeScriptCompile Include="Client\test.ts" />
+		<TypeScriptCompile Include="Client\typings.d.ts" />
+	</ItemGroup>
 
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties package-lock_1json__JSONSchema="http://json.schemastore.org/bower" />
-    </VisualStudio>
-  </ProjectExtensions>
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties package-lock_1json__JSONSchema="http://json.schemastore.org/bower" />
+		</VisualStudio>
+	</ProjectExtensions>
 
 </Project>

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+FROM microsoft/dotnet:2.1.3-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY . .
 WORKDIR /src/src/Web/WebStatus

--- a/src/Web/WebStatus/WebStatus.csproj
+++ b/src/Web/WebStatus/WebStatus.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
-    <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta8" />
-    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1-beta1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
+		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+		<PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+		<PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.0.0-beta9" />
+		<PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric" Version="2.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
-    <ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
+		<ProjectReference Include="..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/test/ServicesTests/Application.FunctionalTests/Application.FunctionalTests.csproj
+++ b/test/ServicesTests/Application.FunctionalTests/Application.FunctionalTests.csproj
@@ -1,95 +1,96 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFrameworkVersion>2.1.3</RuntimeFrameworkVersion>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Services\Location\**" />
-    <Compile Remove="Services\Marketing\**" />
-    <EmbeddedResource Remove="Services\Location\**" />
-    <EmbeddedResource Remove="Services\Marketing\**" />
-    <None Remove="Services\Location\**" />
-    <None Remove="Services\Marketing\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Services\Location\**" />
+		<Compile Remove="Services\Marketing\**" />
+		<EmbeddedResource Remove="Services\Location\**" />
+		<EmbeddedResource Remove="Services\Marketing\**" />
+		<None Remove="Services\Location\**" />
+		<None Remove="Services\Marketing\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Remove="Services\Basket\appsettings.json" />
-    <None Remove="Setup\CatalogBrands.csv" />
-    <None Remove="Setup\CatalogItems.csv" />
-    <None Remove="Setup\CatalogItems.zip" />
-    <None Remove="Setup\CatalogTypes.csv" />
-    <None Remove="Services\Ordering\appsettings.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="Services\Basket\appsettings.json" />
+		<None Remove="Setup\CatalogBrands.csv" />
+		<None Remove="Setup\CatalogItems.csv" />
+		<None Remove="Setup\CatalogItems.zip" />
+		<None Remove="Setup\CatalogTypes.csv" />
+		<None Remove="Services\Ordering\appsettings.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="Services\Location\LocationsScenariosBase.cs" />
-    <Compile Include="Services\Location\LocationsTestsStartup.cs" />
-    <Compile Include="Services\Marketing\CampaignScenariosBase.cs" />
-    <Compile Include="Services\Marketing\UserLocationRoleScenariosBase.cs" />
-    <Compile Include="Services\Marketing\MarketingScenarios.cs" />
-    <Compile Include="Services\Marketing\MarketingScenariosBase.cs" />
-    <Compile Include="Services\Marketing\MarketingTestsStartup.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="Services\Location\LocationsScenariosBase.cs" />
+		<Compile Include="Services\Location\LocationsTestsStartup.cs" />
+		<Compile Include="Services\Marketing\CampaignScenariosBase.cs" />
+		<Compile Include="Services\Marketing\UserLocationRoleScenariosBase.cs" />
+		<Compile Include="Services\Marketing\MarketingScenarios.cs" />
+		<Compile Include="Services\Marketing\MarketingScenariosBase.cs" />
+		<Compile Include="Services\Marketing\MarketingTestsStartup.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Services\Basket\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Services\Catalog\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogBrands.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogItems.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogItems.zip">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Setup\CatalogTypes.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Services\Location\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Services\Marketing\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Services\Ordering\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="Services\Basket\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Services\Catalog\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogBrands.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogItems.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogItems.zip">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Setup\CatalogTypes.csv">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Services\Location\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Services\Marketing\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="Services\Ordering\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Services\Basket\Basket.API\Basket.API.csproj" />
-    <ProjectReference Include="..\..\..\src\Services\Catalog\Catalog.API\Catalog.API.csproj" />
-    <ProjectReference Include="..\..\..\src\Services\Location\Locations.API\Locations.API.csproj" />
-    <ProjectReference Include="..\..\..\src\Services\Marketing\Marketing.API\Marketing.API.csproj" />
-    <ProjectReference Include="..\..\..\src\Services\Ordering\Ordering.API\Ordering.API.csproj" />
-    <ProjectReference Include="..\..\..\src\Web\WebMVC\WebMVC.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\Services\Basket\Basket.API\Basket.API.csproj" />
+		<ProjectReference Include="..\..\..\src\Services\Catalog\Catalog.API\Catalog.API.csproj" />
+		<ProjectReference Include="..\..\..\src\Services\Location\Locations.API\Locations.API.csproj" />
+		<ProjectReference Include="..\..\..\src\Services\Marketing\Marketing.API\Marketing.API.csproj" />
+		<ProjectReference Include="..\..\..\src\Services\Ordering\Ordering.API\Ordering.API.csproj" />
+		<ProjectReference Include="..\..\..\src\Web\WebMVC\WebMVC.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="Services\Locations\appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="Services\Locations\appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+	<ItemGroup>
+		<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
a. Updated NuGet References to support ASP.NET Core 2.1.3  …
    1. Microsoft.ApplicationInsights.AspNetCore 2.2.1->2.4.1
    2. Microsoft.ApplicationInsights.DependencyCollector 2.6.1-> 2.7.2
    3. Microsoft.ApplicationInsights.ServiceFabric 2.1.1-beta1->2.1.1
    4. Microsoft.Extensions.Logging.AzureAppServices 2.1.0-> 2.1.1
    5. Microsoft.AspNetCore.App 2.1.0->2.1.3
    6. Microsoft.VisualStudio.Azure.Fabric.MSBuild 1.6.5->1.6.7
    7. Microsoft.EntityFrameworkCore, Microsoft.EntityFrameworkCore.Design, Microsoft.EntityFrameworkCore.Relational, Microsoft.EntityFrameworkCore.SqlServer 2.1.0->2.1.2
    8. Microsoft.AspNetCore.Hosting 2.1.0->2.1.1
    9. Microsoft.Extensions.Logging 2.1.0->2.1.1
  10. Polly 6.0.1->6.1.0
  11. Microsoft.Extensions.Http.Polly 2.1.0->2.1.1
  12.  Microsoft.AspNetCore.DataProtection.Redis 0.3.3->0.4.1
  13. Microsoft.Extensions.Configuration.AzureKeyVault 2.1.0-->2.1.1
  14. Swashbuckle.AspNetCore 1.1.0->2.4.0
  15. Microsoft.AspNetCore.SignalR, Microsoft.AspNetCore.SignalR.Core, Microsoft.AspNetCore.SignalR.Redis 1.0.0->1.0.3
b. Updated NuGet packages
    1. BuildBundleMinifier 2.6.375->2.8.391
    2. Microsoft.ApplicationInsights.Kubernetes 1.0.0-beta8->1.0.0-beta9
c, Updated Test Projects to support ASP.NET Core 2.1
    1. Microsoft.NET.Test.Sdk 15.7.0->15.8.0
    2. Microsoft.AspNetCore.TestHost 2.1.0->2.1.1
d. Updated container images in docker files 
    1. runtime image 2.1->2.1.3
    2. sdk image 2.1->2.1.401
e. Removed DotNetCliToolsReference from project files
