### PR TITLE
Changed path separator to make powershell script work on Windows and Mac

### DIFF
--- a/k8s/deploy-ingress-azure.ps1
+++ b/k8s/deploy-ingress-azure.ps1
@@ -1,3 +1,3 @@
-﻿kubectl patch deployment -n ingress-nginx nginx-ingress-controller --type=json --patch="$(cat nginx-ingress\publish-service-patch.yaml)"
-kubectl apply -f nginx-ingress\azure\service.yaml
-kubectl apply -f nginx-ingress\patch-service-without-rbac.yaml
+﻿kubectl patch deployment -n ingress-nginx nginx-ingress-controller --type=json --patch="$(cat nginx-ingress/publish-service-patch.yaml)"
+kubectl apply -f nginx-ingress/azure/service.yaml
+kubectl apply -f nginx-ingress/patch-service-without-rbac.yaml

--- a/k8s/deploy-ingress.ps1
+++ b/k8s/deploy-ingress.ps1
@@ -1,12 +1,12 @@
 kubectl apply -f ingress.yaml
 
 # Deploy nginx-ingress core files
-kubectl apply -f nginx-ingress\namespace.yaml
-kubectl apply -f nginx-ingress\default-backend.yaml
-kubectl apply -f nginx-ingress\configmap.yaml 
-kubectl apply -f nginx-ingress\tcp-services-configmap.yaml
-kubectl apply -f nginx-ingress\udp-services-configmap.yaml
-kubectl apply -f nginx-ingress\without-rbac.yaml
+kubectl apply -f nginx-ingress/namespace.yaml
+kubectl apply -f nginx-ingress/default-backend.yaml
+kubectl apply -f nginx-ingress/configmap.yaml 
+kubectl apply -f nginx-ingress/tcp-services-configmap.yaml
+kubectl apply -f nginx-ingress/udp-services-configmap.yaml
+kubectl apply -f nginx-ingress/without-rbac.yaml
 
 
 


### PR DESCRIPTION
Fix for #748 
The powershell scripts is tested on both Mac and Windows 10. With the change in file path separator scripts run fine on both the environments.