### PR TITLE
Fix path separator on Mac OS x

### DIFF
--- a/k8s/deploy-ingress.ps1
+++ b/k8s/deploy-ingress.ps1
@@ -1,12 +1,12 @@
 kubectl apply -f ingress.yaml
 
 # Deploy nginx-ingress core files
-kubectl apply -f nginx-ingress\namespace.yaml
-kubectl apply -f nginx-ingress\default-backend.yaml
-kubectl apply -f nginx-ingress\configmap.yaml 
-kubectl apply -f nginx-ingress\tcp-services-configmap.yaml
-kubectl apply -f nginx-ingress\udp-services-configmap.yaml
-kubectl apply -f nginx-ingress\without-rbac.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)namespace.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)default-backend.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)configmap.yaml 
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)tcp-services-configmap.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)udp-services-configmap.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)without-rbac.yaml
 
 
 


### PR DESCRIPTION
On Mac, the original script doesn't work. Thanks to $([IO.Path]::DirectorySeparatorChar), we can easily provide a standard way to execute correctly this script

**Tested on**
Mac OS x High Sierra 10.13.6

**PS Version**                                                                                                                                                                                                                         
PSVersion: 6.0.0-alpha                                                                                                                                                                                               
BuildVersion: 3.0.0.0                                                                                                                                                                                                                                  
GitCommitId: v6.0.0-alpha.9                                                                                                                                                                                                                           
