### PR TITLE
Fix path separator on Mac OS x (deploy-ingress-azure.ps1)

### DIFF
--- a/k8s/deploy-ingress-azure.ps1
+++ b/k8s/deploy-ingress-azure.ps1
@@ -1,3 +1,3 @@
-﻿kubectl patch deployment -n ingress-nginx nginx-ingress-controller --type=json --patch="$(cat nginx-ingress\publish-service-patch.yaml)"
-kubectl apply -f nginx-ingress\azure\service.yaml
-kubectl apply -f nginx-ingress\patch-service-without-rbac.yaml
+kubectl patch deployment -n ingress-nginx nginx-ingress-controller --type=json --patch="$(cat nginx-ingress$([IO.Path]::DirectorySeparatorChar)publish-service-patch.yaml)"
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)azure$([IO.Path]::DirectorySeparatorChar)service.yaml
+kubectl apply -f nginx-ingress$([IO.Path]::DirectorySeparatorChar)patch-service-without-rbac.yaml


### PR DESCRIPTION
On Mac, the original script doesn't work. Thanks to $([IO.Path]::DirectorySeparatorChar), we can easily provide a standard way to execute correctly this script

**Tested on**
Mac OS x High Sierra 10.13.6

**PS Version**
PSVersion: 6.0.0-alpha
BuildVersion: 3.0.0.0
GitCommitId: v6.0.0-alpha.9