### PR TITLE
Update eShopOnContainers.TestRunner.iOS/Info.plist

### DIFF
--- a/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/Info.plist
+++ b/src/Mobile/eShopOnContainers/eShopOnContainers.TestRunner.iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string></string>
+	<string>9.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
Matching MinOSVersion to the same in eShopOnContainers.iOS/Info.plist. Required for successful builds given the currently set architectures.