### PR TITLE
limit helm delete to eshop

### DIFF
--- a/k8s/helm/deploy-all.ps1
+++ b/k8s/helm/deploy-all.ps1
@@ -44,7 +44,7 @@ if ([string]::IsNullOrEmpty($dns)) {
 
 if ($clean) {
     Write-Host "Cleaning previous helm releases..." -ForegroundColor Green
-    helm delete --purge $(helm ls -q) 
+    helm delete --purge $(helm ls -q eshop) 
     Write-Host "Previous releases deleted" -ForegroundColor Green
 }
 


### PR DESCRIPTION
All,
I would like to make a small suggestion to not blindly destroy all the containers within the default namespace.
This is too intrusive if the Kubernetes Cluster is not only serving for eShop purposes.
Therefore I would like to suggest that the cleanup tasks gets modified as followed:

Current
````powershell
if ($clean) {
    Write-Host "Cleaning previous helm releases..." -ForegroundColor Green
    helm delete --purge $(helm ls -q) 
    Write-Host "Previous releases deleted" -ForegroundColor Green
}
````
Proposal:
````powershell
if ($clean) {
    Write-Host "Cleaning previous helm releases..." -ForegroundColor Green
   helm delete --purge $(helm ls -q eshop)
   Write-Host "Previous releases deleted" -ForegroundColor Green
}
````
This will filter out only those helm deployments containing the word "eshop".

https://github.com/dotnet-architecture/eShopOnContainers/blob/167bb167ff94a7b15e9b4eaaee697ffbecebc8c4/k8s/helm/deploy-all.ps1#L47