### PR TITLE
fixed libman errors

### DIFF
--- a/src/Services/Identity/Identity.API/libman.json
+++ b/src/Services/Identity/Identity.API/libman.json
@@ -9,14 +9,6 @@
     {
       "provider": "unpkg",
       "library": "bootstrap@4.1.3",
-      "files": [
-        "dist/css/bootstrap.css",
-        "dist/css/bootstrap.css.map",
-        "dist/css/bootstrap.min.css",
-        "dist/css/bootstrap.min.css.map",
-        "dist/js/bootstrap.js",
-        "dist/js/bootstrap.min.js"
-      ],
       "destination": "wwwroot/lib/bootstrap/"
     },
     {
@@ -25,11 +17,7 @@
     },
     {
       "library": "jquery-validate@1.17.0",
-      "destination": "wwwroot/lib/jquery-validate/",
-      "files": [
-        "jquery.validate.min.js",
-        "jquery.validate.js"
-      ]
+      "destination": "wwwroot/lib/jquery-validate/"
     }
   ]
 }

--- a/src/Web/WebMVC/libman.json
+++ b/src/Web/WebMVC/libman.json
@@ -9,14 +9,6 @@
     {
       "provider": "unpkg",
       "library": "bootstrap@4.3.1",
-      "files": [
-        "dist/css/bootstrap.css",
-        "dist/css/bootstrap.css.map",
-        "dist/css/bootstrap.min.css",
-        "dist/css/bootstrap.min.css.map",
-        "dist/js/bootstrap.js",
-        "dist/js/bootstrap.min.js"
-      ],
       "destination": "wwwroot/lib/bootstrap/"
     },
     {
@@ -25,11 +17,7 @@
     },
     {
       "library": "jquery-validate@1.19.0",
-      "destination": "wwwroot/lib/jquery-validate/",
-      "files": [
-        "jquery.validate.min.js",
-        "jquery.validate.js"
-      ]
+      "destination": "wwwroot/lib/jquery-validate/"
     },
     {
       "library": "toastr.js@2.1.4",
@@ -38,10 +26,6 @@
     {
       "provider": "unpkg",
       "library": "@aspnet/signalr@1.1.2",
-      "files": [    
-        "dist/browser/signalr.js",
-        "dist/browser/signalr.min.js"
-      ],
       "destination": "wwwroot/lib/@aspnet/signalr/"
     }
   ]

--- a/src/Web/WebStatus/libman.json
+++ b/src/Web/WebStatus/libman.json
@@ -9,14 +9,6 @@
     {
       "provider": "unpkg",
       "library": "bootstrap@4.1.3",
-      "files": [
-        "dist/css/bootstrap.css",
-        "dist/css/bootstrap.css.map",
-        "dist/css/bootstrap.min.css",
-        "dist/css/bootstrap.min.css.map",
-        "dist/js/bootstrap.js",
-        "dist/js/bootstrap.min.js"
-      ],
       "destination": "wwwroot/lib/bootstrap/"
     }
   ]


### PR DESCRIPTION
I think the files array that specifies _the files to be downloaded_ should be removed because this is the second solution until it is fixed

because during build, the manifest file of libman, shows an error (see #848), which only fixes in this two ways: [see details here](https://github.com/aspnet/LibraryManager/issues/111)

Note that I'm using VS 2017 15.9.11. However in VS 2019 16.0.0, this issue is resolved, but I think this should not be IDE dependent

and this can only be resolved by any of the following:
1. Removing LibraryManagerBuild NuGet package (which is not right as you suggested)
    So I restored the package.
2. removing the files array which specifies the files to be downloaded by LibMan
3. manual workflow (it would be redundant)
   a. putting the files into **.node_nodules** folder (either manually or by node packages as discussed in [this issue](https://github.com/aspnet/LibraryManager/issues/111)) , 
   2. using _filesystem_ as a source, 
   3. specifying those files from **.node_modules** directory for that library

fixes #985