### PR TITLE
fix missing reference to Microsoft.AspNetCore.App

### DIFF
--- a/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
+++ b/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
+++ b/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Services/Identity/Identity.API/Views/Shared/_LoginPartial.cshtml
+++ b/src/Services/Identity/Identity.API/Views/Shared/_LoginPartial.cshtml
@@ -7,7 +7,7 @@
 
 @if (SignInManager.IsSignedIn(User))
 {
-    <form asp-area="" asp-controller="Account" asp-action="LogOff" method="post" id="logoutForm" class="navbar-right">
+    <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" class="navbar-right">
         <ul class="nav navbar-nav navbar-right">
             <li>
                 <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage">Hello @UserManager.GetUserName(User)!</a>


### PR DESCRIPTION
fix missing reference that was causing Basket Functional Tests to fail -- see https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-2.2#test-app-prerequisites