### PR TITLE
Fix tests projects compilation errors and unit tests failures

### DIFF
--- a/src/Services/Basket/Basket.API/Controllers/BasketController.cs
+++ b/src/Services/Basket/Basket.API/Controllers/BasketController.cs
@@ -41,14 +41,14 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Controllers
         {
             var basket = await _repository.GetBasketAsync(id);
 
-            return basket ?? new CustomerBasket(id);
+            return Ok(basket ?? new CustomerBasket(id));
         }
 
         [HttpPost]
         [ProducesResponseType(typeof(CustomerBasket), (int)HttpStatusCode.OK)]
         public async Task<ActionResult<CustomerBasket>> UpdateBasketAsync([FromBody]CustomerBasket value)
         {
-            return await _repository.UpdateBasketAsync(value);
+            return Ok(await _repository.UpdateBasketAsync(value));
         }
 
         [Route("checkout")]

--- a/src/Services/Basket/Basket.UnitTests/Application/BasketWebApiTest.cs
+++ b/src/Services/Basket/Basket.UnitTests/Application/BasketWebApiTest.cs
@@ -55,7 +55,7 @@ namespace UnitTest.Basket.Application
 
             //Assert
             Assert.Equal((actionResult.Result as OkObjectResult).StatusCode, (int)System.Net.HttpStatusCode.OK);
-            Assert.Equal(((CustomerBasket)actionResult.Value).BuyerId, fakeCustomerId);
+            Assert.Equal((((ObjectResult)actionResult.Result).Value as CustomerBasket).BuyerId, fakeCustomerId);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace UnitTest.Basket.Application
 
             //Assert
             Assert.Equal((actionResult.Result as OkObjectResult).StatusCode, (int)System.Net.HttpStatusCode.OK);
-            Assert.Equal(((CustomerBasket)actionResult.Value).BuyerId, fakeCustomerId);
+            Assert.Equal((((ObjectResult)actionResult.Result).Value as CustomerBasket).BuyerId, fakeCustomerId);
         }
 
         [Fact]

--- a/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
+++ b/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
+++ b/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/Services/Marketing/Marketing.FunctionalTests/Marketing.FunctionalTests.csproj
+++ b/src/Services/Marketing/Marketing.FunctionalTests/Marketing.FunctionalTests.csproj
@@ -17,6 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Services/Marketing/Marketing.FunctionalTests/Properties/launchSettings.json
+++ b/src/Services/Marketing/Marketing.FunctionalTests/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:7496/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Marketing.FunctionalTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:7497/"
+    }
+  }
+}

--- a/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -17,6 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Update unit tests projects as per https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-2.2#test-app-prerequisites

Fix failling unit tests.

Closes https://github.com/dotnet-architecture/eShopOnContainers/pull/991 as it became outdated