### PR TITLE
Get_get_campaign_by_id now fails initially

### DIFF
--- a/src/Services/Marketing/Marketing.FunctionalTests/CampaignScenarios.cs
+++ b/src/Services/Marketing/Marketing.FunctionalTests/CampaignScenarios.cs
@@ -27,7 +27,7 @@ namespace Marketing.FunctionalTests
         [Fact]
         public async Task Get_get_campaign_by_id_and_response_ok_status_code()
         {
-            var campaignId = 81;
+            var campaignId = 2;
             using (var server = CreateServer())
             {
                 var response = await server.CreateClient()


### PR DESCRIPTION
This test is looking for ID = 81, but the test fails when the DB is first built, because the original seed only populates 2 campaign rows. By changing this to ID = 2, the test will pass without having the other POST/PUT tests run several times first.