### PR TITLE
Fix marketing functional tests that rely on existing campaign

### DIFF
--- a/src/Services/Marketing/Marketing.FunctionalTests/UserLocationRoleScenarios.cs
+++ b/src/Services/Marketing/Marketing.FunctionalTests/UserLocationRoleScenarios.cs
@@ -28,7 +28,7 @@ namespace Marketing.FunctionalTests
         [Fact]
         public async Task Post_add_new_user_location_rule_and_response_ok_status_code()
         {
-            var campaignId = 81;
+            var campaignId = 2;
 
             using (var server = CreateServer())
             {
@@ -44,7 +44,7 @@ namespace Marketing.FunctionalTests
         [Fact]
         public async Task Delete_delete_user_location_role_and_response_not_content_status_code()
         {
-            var campaignId = 81;
+            var campaignId = 2;
 
             using (var server = CreateServer())
             {


### PR DESCRIPTION
There are 2 tests that use campaignId = 81 that fail when a campaign with that Id does not exist. This is exactly the same scenario as seen in PR #1004. 