### PR TITLE
model declarations in razor views resulting in unsolved references

### DIFF
--- a/src/Web/WebMVC/Views/Campaigns/Details.cshtml
+++ b/src/Web/WebMVC/Views/Campaigns/Details.cshtml
@@ -1,6 +1,8 @@
+@model CampaignItem
+
 @{
     ViewData["Title"] = "Campaign details";
-    @model CampaignItem
+
     var headerList= new List<Header>() {
         new Header() { Controller = "Catalog", Text = "Back to catalog" },
         new Header() { Controller = "Campaigns", Text = "Back to Campaigns" } };
@@ -18,7 +20,7 @@
         <img class="card-img-top" src="@Model.PictureUri" alt="Card image cap">
         <div class="card-body">
             <h4 class="card-title">@Model.Name</h4>
-            <p class="card-text">@Model.Description</p>            
+            <p class="card-text">@Model.Description</p>
         </div>
         <div class="card-footer">
             <small class="text-muted">

--- a/src/Web/WebMVC/Views/Campaigns/Index.cshtml
+++ b/src/Web/WebMVC/Views/Campaigns/Index.cshtml
@@ -1,6 +1,8 @@
+@model WebMVC.ViewModels.CampaignViewModel
+
 @{
     ViewData["Title"] = "Campaigns";
-    @model WebMVC.ViewModels.CampaignViewModel
+
     var headerList= new List<Header>() {
         new Header() { Controller = "Catalog", Text = "Back to catalog" } };
 }
@@ -11,23 +13,23 @@
     </div>
 </section>
 
-<partial name="_Header" model="headerList"/>
+<partial name="_Header" model="headerList" />
 
 <div class="container">
     <br />
     <div class="row">
-        
+
         @if (!ViewData.ModelState.IsValid)
         {
-            <div class="alert alert-warning">
-                @Html.ValidationSummary(false)
-            </div>
-        }        
+        <div class="alert alert-warning">
+            @Html.ValidationSummary(false)
+        </div>
+        }
 
         <div class="col-md-12">
             <div class="esh-campaigns-items" style="font-weight: 300;">
                 UPDATE USER LOCATION
-            </div>            
+            </div>
             <br />
             <form class="form-inline" asp-action="CreateNewUserLocation" method="post">
                 <label class="sr-only" for="longitudeInput">Name</label>
@@ -44,33 +46,33 @@
                         <span class="input-group-text" id="inputGroup-sizing-default">Lon</span>
                     </div>
                     <input type="text" class="form-control mb-2 mr-sm-2 mb-sm-0" id="longitudeInput" asp-for="Lon" placeholder="Longitude">
-                </div>               
+                </div>
 
                 <div class="input-group mb-2 mr-sm-2 mb-sm-0 col-md-2">
                     <input type="submit" value="Update" class="btn esh-campaigns-form-button" />
                 </div>
             </form>
-        </div>        
-    </div>    
+        </div>
+    </div>
     <br />
-        @if (Model != null && Model.CampaignItems !=null && Model.CampaignItems.Any())
+    @if (Model != null && Model.CampaignItems !=null && Model.CampaignItems.Any())
         {
-            <div class="card-group esh-campaigns-items row">
-                @foreach (var catalogItem in Model.CampaignItems)
+    <div class="card-group esh-campaigns-items row">
+        @foreach (var catalogItem in Model.CampaignItems)
                 {
-                    <div class="esh-campaigns-item col-md-4">
-                        <partial name="_campaign" model="catalogItem"/>
-                    </div>
+        <div class="esh-campaigns-item col-md-4">
+            <partial name="_campaign" model="catalogItem" />
+        </div>
                 }
-            </div>
+    </div>
 
-            <partial name="_pagination" for="PaginationInfo" />
+    <partial name="_pagination" for="PaginationInfo" />
         }
         else
         {
-            <div class="esh-campaigns-items row">
-                THERE ARE NO CAMPAIGNS
-            </div>
+    <div class="esh-campaigns-items row">
+        THERE ARE NO CAMPAIGNS
+    </div>
         }
 </div>
 

--- a/src/Web/WebMVC/Views/Catalog/Index.cshtml
+++ b/src/Web/WebMVC/Views/Catalog/Index.cshtml
@@ -1,6 +1,7 @@
-﻿@{
+﻿@model Microsoft.eShopOnContainers.WebMVC.ViewModels.CatalogViewModels.IndexViewModel
+
+@{
     ViewData["Title"] = "Catalog";
-    @model Microsoft.eShopOnContainers.WebMVC.ViewModels.CatalogViewModels.IndexViewModel
 }
 <section class="esh-catalog-hero">
     <div class="container">
@@ -27,31 +28,31 @@
         <br />
         @if(ViewBag.BasketInoperativeMsg != null)
         {
-            <div class="alert alert-warning" role="alert">
-                &nbsp;@ViewBag.BasketInoperativeMsg
-            </div>
+        <div class="alert alert-warning" role="alert">
+            &nbsp;@ViewBag.BasketInoperativeMsg
+        </div>
         }
     </div>
 
     @if (Model.CatalogItems.Count() > 0)
     {
-        <partial name="_pagination" for="PaginationInfo" />
+    <partial name="_pagination" for="PaginationInfo" />
 
-        <div class="esh-catalog-items row">
-            @foreach (var catalogItem in Model.CatalogItems)
+    <div class="esh-catalog-items row">
+        @foreach (var catalogItem in Model.CatalogItems)
             {
-                <div class="esh-catalog-item col-md-4">
-                    <partial name="_product" model="catalogItem"/>
-                </div>
-            }
+        <div class="esh-catalog-item col-md-4">
+            <partial name="_product" model="catalogItem" />
         </div>
+            }
+    </div>
 
-        <partial name="_pagination" for="PaginationInfo"/>
+    <partial name="_pagination" for="PaginationInfo" />
     }
     else
     {
-        <div class="esh-catalog-items row">
-            THERE ARE NO RESULTS THAT MATCH YOUR SEARCH
-        </div>
+    <div class="esh-catalog-items row">
+        THERE ARE NO RESULTS THAT MATCH YOUR SEARCH
+    </div>
     }
 </div>


### PR DESCRIPTION
In some razor views, the model declaration is embedded inside a code block, which makes it difficult for Visual Studio to resolve the model references. This PR moves the model declaration for the affected views outside of the code blocks.