### PR TITLE
Add Powershell script to set network category to private for DockerNAT.

### DIFF
--- a/cli-windows/set-dockernat-networkategory-to-private.ps1
+++ b/cli-windows/set-dockernat-networkategory-to-private.ps1
@@ -1,0 +1,1 @@
+﻿Get-NetConnectionProfile | Where-Object { $_.InterfaceAlias -match "(DockerNAT)" } | ForEach-Object { Set-NetConnectionProfile -InterfaceIndex $_.InterfaceIndex -NetworkCategory Private }

--- a/cli-windows/set-dockernat-networkategory-to-private.ps1
+++ b/cli-windows/set-dockernat-networkategory-to-private.ps1
@@ -1,1 +1,2 @@
-﻿Get-NetConnectionProfile | Where-Object { $_.InterfaceAlias -match "(DockerNAT)" } | ForEach-Object { Set-NetConnectionProfile -InterfaceIndex $_.InterfaceIndex -NetworkCategory Private }
+﻿ #Requires -RunAsAdministrator
+ Get-NetConnectionProfile | Where-Object { $_.InterfaceAlias -match "(DockerNAT)" } | ForEach-Object { Set-NetConnectionProfile -InterfaceIndex $_.InterfaceIndex -NetworkCategory Private }


### PR DESCRIPTION
Adding powershell script to set DockerNAT network category to private which solves the problem referred in https://github.com/dotnet-architecture/eShopOnContainers/issues/295 and proposal from https://github.com/dotnet/docs/issues/11528. 

This can be a workaround to run this script until docker figures out a better way to solve the issue. 
The setting is required to be done at restart, however, setting this as scheduled task to run this script might help. (I can update the documentation too once this is accepted and merged)