### PR TITLE
Fix restore packages script 

### DIFF
--- a/run-docker-compose-build.ps1
+++ b/run-docker-compose-build.ps1
@@ -1,6 +1,6 @@
 $startTime = $(Get-Date)
 
-docker-compose build
+docker-compose build --build-arg RUN=scripts/restore-packages
 
 $elapsedTime = $(Get-Date) - $startTime
 

--- a/scripts/restore-packages
+++ b/scripts/restore-packages
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 for f in /src/csproj-files/*.csproj; do dotnet restore $f; done


### PR DESCRIPTION
Remove unneeded `#!/bin/bash` from script and line endings, to avoid errors from CRLF line endings that come from git config on Windows