### PR TITLE
Fix empty health checks view when running from VS

### DIFF
--- a/src/Web/WebStatus/appsettings.json
+++ b/src/Web/WebStatus/appsettings.json
@@ -1,5 +1,75 @@
 ﻿{
   "HealthChecks-UI": {
+    "HealthChecks": [
+      {
+        "Name": "Ordering HTTP Check",
+        "Uri": "http://localhost:5102/hc"
+      },
+      {
+        "Name": "Ordering HTTP Background Check",
+        "Uri": "http://localhost:5111/hc"
+      },
+      {
+        "Name": "Basket HTTP Check",
+        "Uri": "http://localhost:5103/hc"
+      },
+      {
+        "Name": "Catalog HTTP Check",
+        "Uri": "http://localhost:5101/hc"
+      },
+      {
+        "Name": "Identity HTTP Check",
+        "Uri": "http://localhost:5105/hc"
+      },
+      {
+        "Name": "Marketing HTTP Check",
+        "Uri": "http://localhost:5110/hc"
+      },
+      {
+        "Name": "Locations HTTP Check",
+        "Uri": "http://localhost:5109/hc"
+      },
+      {
+        "Name": "Payments HTTP Check",
+        "Uri": "http://localhost:5108/hc"
+      },
+      {
+        "Name": "WebMVC HTTP Check",
+        "Uri": "http://localhost:5100/hc"
+      },
+      {
+        "Name": "WebSPA HTTP Check",
+        "Uri": "http://localhost:5104/hc"
+      },
+      {
+        "Name": "SignalR HTTP Check",
+        "Uri": "http://localhost:5112/hc"
+      },
+      {
+        "Name": "Mobile Shopping API GW HTTP Check",
+        "Uri": "http://localhost:5200/hc"
+      },
+      {
+        "Name": "Mobile Marketing API GW HTTP Check",
+        "Uri": "http://localhost:5201/hc"
+      },
+      {
+        "Name": "Web Shopping API GW HTTP Check",
+        "Uri": "http://localhost:5202/hc"
+      },
+      {
+        "Name": "Web Marketing API GW HTTP Check",
+        "Uri": "http://localhost:5203/hc"
+      },
+      {
+        "Name": "Mobile Shopping Aggregator HTTP Check",
+        "Uri": "http://localhost:5120/hc"
+      },
+      {
+        "Name": "Web Shopping Aggregator HTTP Check",
+        "Uri": "http://localhost:5121/hc"
+      }
+    ],
     "EvaluationTimeOnSeconds": 10,
     "MinimumSecondsBetweenFailureNotifications": 60
   },
@@ -14,13 +84,13 @@
         "System": "Warning"
       }
     }
-    },
-    "Webhooks": [
-      {
-        "Name": "",
-        "Uri": "",
-        "Payload": "",
-        "RestoredPayload": ""
-      }
-    ]
+  },
+  "Webhooks": [
+    {
+      "Name": "",
+      "Uri": "",
+      "Payload": "",
+      "RestoredPayload": ""
+    }
+  ]
 }


### PR DESCRIPTION
Added health checks urls in appsettings.json, just as they are in appsettings.Development.json.

It looks like when running from VS appsettings.json take precedence over the environment variables in docker-compose.override.yml.

Fixes https://github.com/dotnet-architecture/eShopOnContainers/issues/1024