### PR TITLE
provide support for cancellation tokens in command handlers

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/Commands/CancelOrderCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/CancelOrderCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Ordering.API.Application.Commands
             }
 
             orderToUpdate.SetCancelledStatus();
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
@@ -58,7 +58,7 @@
             _orderRepository.Add(order);
 
             return await _orderRepository.UnitOfWork
-                .SaveEntitiesAsync();
+                .SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/IdentifiedCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/IdentifiedCommandHandler.cs
@@ -96,7 +96,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.API.Application.Commands
                         command);
 
                     // Send the embeded business command to mediator so it runs its related CommandHandler 
-                    var result = await _mediator.Send(command);
+                    var result = await _mediator.Send(command, cancellationToken);
 
                     _logger.LogInformation(
                         "----- Command result: {@Result} - {CommandName} - {IdProperty}: {CommandId} ({@Command})",

--- a/src/Services/Ordering/Ordering.API/Application/Commands/SetAwaitingValidationOrderStatusCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/SetAwaitingValidationOrderStatusCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Ordering.API.Application.Commands
             }
 
             orderToUpdate.SetAwaitingValidationStatus();
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/SetPaidOrderStatusCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/SetPaidOrderStatusCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Ordering.API.Application.Commands
         public async Task<bool> Handle(SetPaidOrderStatusCommand command, CancellationToken cancellationToken)
         {
             // Simulate a work time for validating the payment
-            await Task.Delay(10000);
+            await Task.Delay(10000, cancellationToken);
 
             var orderToUpdate = await _orderRepository.GetAsync(command.OrderNumber);
             if(orderToUpdate == null)
@@ -36,7 +36,7 @@ namespace Ordering.API.Application.Commands
             }
 
             orderToUpdate.SetPaidStatus();
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/SetStockConfirmedOrderStatusCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/SetStockConfirmedOrderStatusCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Ordering.API.Application.Commands
         public async Task<bool> Handle(SetStockConfirmedOrderStatusCommand command, CancellationToken cancellationToken)
         {
             // Simulate a work time for confirming the stock
-            await Task.Delay(10000);
+            await Task.Delay(10000, cancellationToken);
 
             var orderToUpdate = await _orderRepository.GetAsync(command.OrderNumber);
             if(orderToUpdate == null)
@@ -36,7 +36,7 @@ namespace Ordering.API.Application.Commands
             }
 
             orderToUpdate.SetStockConfirmedStatus();
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/SetStockRejectedOrderStatusCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/SetStockRejectedOrderStatusCommandHandler.cs
@@ -27,7 +27,7 @@ namespace Ordering.API.Application.Commands
         public async Task<bool> Handle(SetStockRejectedOrderStatusCommand command, CancellationToken cancellationToken)
         {
             // Simulate a work time for rejecting the stock
-            await Task.Delay(10000);
+            await Task.Delay(10000, cancellationToken);
 
             var orderToUpdate = await _orderRepository.GetAsync(command.OrderNumber);
             if(orderToUpdate == null)
@@ -37,7 +37,7 @@ namespace Ordering.API.Application.Commands
 
             orderToUpdate.SetCancelledStatusWhenStockIsRejected(command.OrderStockItems);
 
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/Commands/ShipOrderCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/ShipOrderCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Ordering.API.Application.Commands
             }
 
             orderToUpdate.SetShippedStatus();
-            return await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+            return await _orderRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
         }
     }
 

--- a/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/OrderStartedEvent/ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/OrderStartedEvent/ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler.cs
@@ -56,7 +56,7 @@ namespace Ordering.API.Application.DomainEventHandlers.OrderStartedEvent
                 _buyerRepository.Add(buyer);
 
             await _buyerRepository.UnitOfWork
-                .SaveEntitiesAsync();
+                .SaveEntitiesAsync(cancellationToken);
 
             var orderStatusChangedTosubmittedIntegrationEvent = new OrderStatusChangedToSubmittedIntegrationEvent(orderStartedEvent.Order.Id, orderStartedEvent.Order.OrderStatus.Name, buyer.Name);
             await _orderingIntegrationEventService.AddAndSaveEventAsync(orderStatusChangedTosubmittedIntegrationEvent);

--- a/src/Services/Ordering/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/OrderingContext.cs
@@ -64,7 +64,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Infrastructure
 
             // After executing this line all the changes (from the Command Handler and Domain Event Handlers) 
             // performed through the DbContext will be committed
-            var result = await base.SaveChangesAsync();
+            var result = await base.SaveChangesAsync(cancellationToken);
 
             return true;
         }


### PR DESCRIPTION
MediatR supports cancellation tokens in it's IRequestHandler interface, but currently none of the command handlers do anything with them if one is passed.