### PR TITLE
UpdateAllBasketAsync should use the current basket if it exists

### DIFF
--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Controllers/BasketController.cs
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Controllers/BasketController.cs
@@ -36,15 +36,9 @@ namespace Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator.Controllers
             }
 
             // Retrieve the current basket
-            var currentBasket = await _basket.GetByIdAsync(data.BuyerId);
-
-            if (currentBasket == null)
-            {
-                currentBasket = new BasketData(data.BuyerId);
-            }
+            var basket = await _basket.GetByIdAsync(data.BuyerId) ?? new BasketData(data.BuyerId);
 
             var catalogItems = await _catalog.GetCatalogItemsAsync(data.Items.Select(x => x.ProductId));
-            var newBasket = new BasketData(data.BuyerId);
 
             foreach (var bitem in data.Items)
             {
@@ -54,7 +48,7 @@ namespace Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator.Controllers
                     return BadRequest($"Basket refers to a non-existing catalog item ({bitem.ProductId})");
                 }
 
-                newBasket.Items.Add(new BasketDataItem()
+                basket.Items.Add(new BasketDataItem()
                 {
                     Id = bitem.Id,
                     ProductId = catalogItem.Id.ToString(),
@@ -65,9 +59,9 @@ namespace Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator.Controllers
                 });
             }
 
-            await _basket.UpdateAsync(newBasket);
+            await _basket.UpdateAsync(basket);
 
-            return newBasket;
+            return basket;
         }
 
         [HttpPut]

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Controllers/BasketController.cs
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Controllers/BasketController.cs
@@ -36,14 +36,9 @@ namespace Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator.Controllers
             }
 
             // Retrieve the current basket
-            var currentBasket = await _basket.GetByIdAsync(data.BuyerId);
-            if (currentBasket == null)
-            {
-                currentBasket = new BasketData(data.BuyerId);
-            }
+            var basket = await _basket.GetByIdAsync(data.BuyerId) ?? new BasketData(data.BuyerId);
 
             var catalogItems = await _catalog.GetCatalogItemsAsync(data.Items.Select(x => x.ProductId));
-            var newBasket = new BasketData(data.BuyerId);
 
             foreach (var bitem in data.Items)
             {
@@ -53,7 +48,7 @@ namespace Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator.Controllers
                     return BadRequest($"Basket refers to a non-existing catalog item ({bitem.ProductId})");
                 }
 
-                newBasket.Items.Add(new BasketDataItem()
+                basket.Items.Add(new BasketDataItem()
                 {
                     Id = bitem.Id,
                     ProductId = catalogItem.Id.ToString(),
@@ -64,9 +59,9 @@ namespace Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator.Controllers
                 });
             }
 
-            await _basket.UpdateAsync(newBasket);
+            await _basket.UpdateAsync(basket);
 
-            return newBasket;
+            return basket;
         }
 
         [HttpPut]


### PR DESCRIPTION
In the case where there is an existing basket for the current buyer, the UpdateAllBasketAsync action in the BasketController will ignore it. Instead it will always instantiate and return a new basket. This fix uses the current basket if one already exists.