### PR TITLE
Several improvement and fixes in deploy-all.sh

### DIFF
--- a/k8s/helm/deploy-all.sh
+++ b/k8s/helm/deploy-all.sh
@@ -37,7 +37,7 @@ Parameters:
     This is useful for production environments where infrastructure is hosted outside the Kubernetes cluster.
   -t | --tag <docker image tag>
     The tag used for the newly created docker images. Default: newly created, date-based timestamp, with 1-minute resolution.
-  -u | --docker-user <docker username>
+  -u | --docker-username <docker username>
     The Docker username used to logon to the custom registry, supplied using the -r parameter.
   --use-local-k8s
     Deploy to a locally installed Kubernetes (default: false).
@@ -86,7 +86,7 @@ while [[ $# -gt 0 ]]; do
     -n | --app-name )
       app_name="$2"; shift 2;;
     -p | --docker-password )
-      docker_password="$2"; shift;;
+      docker_password="$2"; shift 2;;
     -r | --registry )
       container_registry="$2"; shift 2;;
     --skip-clean )

--- a/k8s/helm/deploy-all.sh
+++ b/k8s/helm/deploy-all.sh
@@ -38,7 +38,7 @@ Parameters:
     This is useful for production environments where infrastructure is hosted outside the Kubernetes cluster.
   -t | --tag <docker image tag>
     The tag used for the newly created docker images. Default: newly created, date-based timestamp, with 1-minute resolution.
-  -u | --docker-user <docker username>
+  -u | --docker-username <docker username>
     The Docker username used to logon to the custom registry, supplied using the -r parameter.
   --use-local-k8s
     Deploy to a locally installed Kubernetes (default: false).


### PR DESCRIPTION
Several fixes in this PR:

  * `--docker-password` argument was not correctly handled.
  * `--docker-username` was not correctly documented in `usage()`, `--docker-user` was incorrectly referenced instead.
  * `--dns aks` argument was not documented at usage.
  * No authentication to custom registry was performed in the script, so `--docker-username` and `--docker-password` arguments didn't have any effect. Now it is possible to push the images to custom registry.
  * `image_tag` was not aligned with `docker-compose build` output, as it will add `linux-` prefix according to the platform. A check to detect this and tag the images accordingly has been implemented.