### PR TITLE
Display the type name in the log message

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
@@ -61,7 +61,7 @@
         public void SubscribeDynamic<TH>(string eventName)
             where TH : IDynamicIntegrationEventHandler
         {
-            _logger.LogInformation("Subscribing to dynamic event {EventName} with {EventHandler}", eventName, nameof(TH));
+            _logger.LogInformation("Subscribing to dynamic event {EventName} with {EventHandler}", eventName, typeof(TH).Name);
 
             _subsManager.AddDynamicSubscription<TH>(eventName);
         }
@@ -89,7 +89,7 @@
                 }
             }
 
-            _logger.LogInformation("Subscribing to event {EventName} with {EventHandler}", eventName, nameof(TH));
+            _logger.LogInformation("Subscribing to event {EventName} with {EventHandler}", eventName, typeof(TH).Name);
 
             _subsManager.AddSubscription<T, TH>();
         }


### PR DESCRIPTION
Currently, the code `nameof(TH)` is printing the value TH in the message. This PR will change it to print the type name in the message e.g. `MyEventHandler`.