### PR TITLE
Use internal docker dns names

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -4,17 +4,28 @@
 
 # The IP below should be swapped to your real IP or DNS name, like 192.168.88.248, etc. if testing from remote browsers or mobile devices
 
-# Use this value to run the app locally in Windows/Linux
-ESHOP_EXTERNAL_DNS_NAME_OR_IP=localhost
+# Use this values to run the app locally in Windows
+ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.win.localhost
+ESHOP_STORAGE_CATALOG_URL=http://docker.for.win.localhost:5202/c/api/v1/catalog/items/[0]/pic/
+ESHOP_STORAGE_MARKETING_URL=http://docker.for.win.localhost:5110/api/v1/campaigns/[0]/pic/
 
-# Use this value to run the app locally in Mac
-#ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.mac.localhost
+# Use this values to run the app locally in Mac
+# ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.mac.localhost
+# ESHOP_STORAGE_CATALOG_URL=http://docker.for.mac.localhost:5202/c/api/v1/catalog/items/[0]/pic/
+# ESHOP_STORAGE_MARKETING_URL=http://docker.for.mac.localhost:5110/api/v1/campaigns/[0]/pic/
+
+# Use this values to run the app locally in Linux
+# ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.linux.localhost
+# ESHOP_STORAGE_CATALOG_URL=http://docker.for.linux.localhost:5202/c/api/v1/catalog/items/[0]/pic/
+# ESHOP_STORAGE_MARKETING_URL=http://docker.for.linux.localhost:5110/api/v1/campaigns/[0]/pic/
+
+# Configure this values to the cloud storage locations
+# ESHOP_STORAGE_CATALOG_URL=<YourAzureStorage_Catalog_BLOB_URL>
+# ESHOP_STORAGE_MARKETING_URL=<YourAzureStorage_Marketing__BLOB_URL>
 
 ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP=10.121.122.162
 
 #ESHOP_AZURE_REDIS_BASKET_DB=<YourAzureRedisBasketInfo>
-#ESHOP_AZURE_STORAGE_CATALOG_URL=<YourAzureStorage_Catalog_BLOB_URL>
-#ESHOP_AZURE_STORAGE_MARKETING_URL=<YourAzureStorage_Marketing__BLOB_URL>
 #ESHOP_AZURE_SERVICE_BUS=<YourAzureServiceBusInfo>
 #ESHOP_AZURE_COSMOSDB=<YourAzureCosmosDBConnData>
 #ESHOP_AZURE_CATALOG_DB=<YourAzureSQLDBCatalogDBConnString>

--- a/src/Services/Identity/Identity.API/appsettings.json
+++ b/src/Services/Identity/Identity.API/appsettings.json
@@ -23,7 +23,7 @@
   "UseVault": false,
   "Vault": {
     "Name": "eshop",
-    "ClientId": "your-clien-id",
+    "ClientId": "your-client-id",
     "ClientSecret": "your-client-secret"
   },
   "TokenLifetimeMinutes": 120,

--- a/src/docker-compose-tests.override.yml
+++ b/src/docker-compose-tests.override.yml
@@ -90,7 +90,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:80
       - ConnectionString=${ESHOP_AZURE_CATALOG_DB:-Server=sql-data-test;Database=Microsoft.eShopOnContainers.Services.CatalogDb;User Id=sa;Password=Pass@word}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_CATALOG_URL:-http://localhost:5202/c/api/v1/catalog/items/[0]/pic/}
+      - PicBaseUrl=${ESHOP_STORAGE_CATALOG_URL}
       - EventBusConnection=${ESHOP_AZURE_SERVICE_BUS:-rabbitmq-test}
       - EventBusUserName=${ESHOP_SERVICE_BUS_USERNAME}
       - EventBusPassword=${ESHOP_SERVICE_BUS_PASSWORD}
@@ -114,7 +114,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:80
       - ConnectionString=${ESHOP_AZURE_CATALOG_DB:-Server=sql-data-test;Database=Microsoft.eShopOnContainers.Services.CatalogDb;User Id=sa;Password=Pass@word}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_CATALOG_URL:-http://localhost:5202/c/api/v1/catalog/items/[0]/pic/}
+      - PicBaseUrl=${ESHOP_STORAGE_CATALOG_URL}
       - EventBusConnection=${ESHOP_AZURE_SERVICE_BUS:-rabbitmq-test}
       - EventBusUserName=${ESHOP_SERVICE_BUS_USERNAME}
       - EventBusPassword=${ESHOP_SERVICE_BUS_PASSWORD}
@@ -194,7 +194,7 @@ services:
       - identityUrl=http://identity-api
       - IdentityUrlExternal=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
       - CampaignDetailFunctionUri=${ESHOP_AZUREFUNC_CAMPAIGN_DETAILS_URI}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_MARKETING_URL:-http://localhost:5110/api/v1/campaigns/[0]/pic/}
+      - PicBaseUrl=${ESHOP_STORAGE_MARKETING_URL}
       - AzureStorageAccountName=${ESHOP_AZURE_STORAGE_MARKETING_NAME}
       - AzureStorageAccountKey=${ESHOP_AZURE_STORAGE_MARKETING_KEY}
       - AzureServiceBusEnabled=False

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -85,7 +85,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionString=${ESHOP_AZURE_CATALOG_DB:-Server=sqldata;Database=Microsoft.eShopOnContainers.Services.CatalogDb;User Id=sa;Password=Pass@word}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_CATALOG_URL:-http://localhost:5202/c/api/v1/catalog/items/[0]/pic/}   #Local: You need to open your local dev-machine firewall at range 5100-5110.
+      - PicBaseUrl=${ESHOP_STORAGE_CATALOG_URL}
       - EventBusConnection=${ESHOP_AZURE_SERVICE_BUS:-rabbitmq}
       - EventBusUserName=${ESHOP_SERVICE_BUS_USERNAME}
       - EventBusPassword=${ESHOP_SERVICE_BUS_PASSWORD}
@@ -160,7 +160,7 @@ services:
       - identityUrl=http://identity-api
       - IdentityUrlExternal=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
       - CampaignDetailFunctionUri=${ESHOP_AZUREFUNC_CAMPAIGN_DETAILS_URI}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_MARKETING_URL:-http://localhost:5110/api/v1/campaigns/[0]/pic/}
+      - PicBaseUrl=${ESHOP_STORAGE_MARKETING_URL}
       - AzureStorageAccountName=${ESHOP_AZURE_STORAGE_MARKETING_NAME}
       - AzureStorageAccountKey=${ESHOP_AZURE_STORAGE_MARKETING_KEY}
       - AzureServiceBusEnabled=False
@@ -264,7 +264,7 @@ services:
       - MarketingUrlHC=http://marketing-api/hc
       - PaymentUrlHC=http://payment-api/hc
       - LocationUrlHC=http://locations-api/hc
-      - IdentityUrlExternal=http://10.0.75.1:5105
+      - IdentityUrlExternal=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
     ports:
       - "5120:80"
 
@@ -358,7 +358,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:80
       - PurchaseUrl=http://webshoppingapigw
-      - IdentityUrl=http://10.0.75.1:5105
+      - IdentityUrl=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
       - MarketingUrl=http://webmarketingapigw
       - SignalrHubUrl=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5202
       - IdentityUrlHC=http://identity-api/hc
@@ -373,8 +373,8 @@ services:
     environment:
       - ASPNETCORE_URLS=http://0.0.0.0:80
       - Token=6168DB8D-DC58-4094-AF24-483278923590      # Webhooks are registered with this token (any value is valid) but the client won't check it
-      - IdentityUrl=http://10.0.75.1:5105
-      - CallBackUrl=http://localhost:5114
+      - IdentityUrl=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
+      - CallBackUrl=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5114
       - WebhooksUrl=http://webhooks-api
       - SelfUrl=http://webhooks-client/
     ports:

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -38,7 +38,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:80
       - ConnectionString=${ESHOP_AZURE_CATALOG_DB:-Server=sqldata;Database=Microsoft.eShopOnContainers.Services.CatalogDb;User Id=sa;Password=Pass@word}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_CATALOG_URL:-http://localhost:5101/api/v1/catalog/items/[0]/pic/}   #Local: You need to open your local dev-machine firewall at range 5100-5110.
+      - PicBaseUrl=${ESHOP_STORAGE_CATALOG_URL}
       - EventBusConnection=${ESHOP_AZURE_SERVICE_BUS:-rabbitmq}
       - EventBusUserName=${ESHOP_SERVICE_BUS_USERNAME}
       - EventBusPassword=${ESHOP_SERVICE_BUS_PASSWORD}
@@ -122,7 +122,7 @@ services:
       - identityUrl=http://identity-api              #Local: You need to open your local dev-machine firewall at range 5100-5110.
       - IdentityUrlExternal=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5105
       - CampaignDetailFunctionUri=${ESHOP_AZUREFUNC_CAMPAIGN_DETAILS_URI}
-      - PicBaseUrl=${ESHOP_AZURE_STORAGE_MARKETING_URL:-http://localhost:5110/api/v1/campaigns/[0]/pic/}
+      - PicBaseUrl=${ESHOP_STORAGE_MARKETING_URL}
       - AzureStorageAccountName=${ESHOP_AZURE_STORAGE_MARKETING_NAME}
       - AzureStorageAccountKey=${ESHOP_AZURE_STORAGE_MARKETING_KEY}
       - AzureServiceBusEnabled=False


### PR DESCRIPTION
Change references from `localhost` to `docker.for.win.localhost` to solve MVC login when using Docker Desktop 2.2.0.0

See the [.env file](https://github.com/dotnet-architecture/eShopOnContainers/blob/fix/docker-2.2-mvc-login/src/.env) for other platforms.

For testing!