### PR TITLE
Overload `==` and `!=` in ValueObject

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/SeedWork/ValueObject.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/ValueObject.cs
@@ -5,7 +5,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
 {
     public abstract class ValueObject
     {
-        protected static bool EqualOperator(ValueObject left, ValueObject right)
+        public static bool operator ==(ValueObject left, ValueObject right)
         {
             if (ReferenceEquals(left, null) ^ ReferenceEquals(right, null))
             {
@@ -14,9 +14,9 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             return ReferenceEquals(left, null) || left.Equals(right);
         }
 
-        protected static bool NotEqualOperator(ValueObject left, ValueObject right)
+        public static bool operator !=(ValueObject left, ValueObject right)
         {
-            return !(EqualOperator(left, right));
+            return !(left == right);
         }
 
         protected abstract IEnumerable<object> GetAtomicValues();

--- a/src/Services/Ordering/Ordering.UnitTests/Domain/AddressTest.cs
+++ b/src/Services/Ordering/Ordering.UnitTests/Domain/AddressTest.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.OrderAggregate;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Ordering.UnitTests.Domain
+{
+    public class AddressTest
+    {
+        [Fact]
+        public void equal_addresses_should_be_equal()
+        {
+            // Arrange
+            var left = CreateValidAddress();
+            var right = CreateValidAddress();
+
+            // Act and Assert
+            Assert.Equal(left, right);
+            Assert.True(left == right);
+        }
+
+        private Address CreateValidAddress() => new Address(
+                street: "FakeStreet",
+                city: "FakeCity",
+                state: "FakeState",
+                country: "FakeCountry",
+                zipcode: "FakeZipCode");
+    }
+}


### PR DESCRIPTION
I was reading [these docs](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/implement-value-objects) and found it a bit confusing that the `ValueObject` class contains the methods `EqualOperator` and `NotEqualOperator`, but it doesn't override these operators.

I suggest to override the `==` and `!=` operators instead.

If this is approved I can make a similar PR in the docs repo to update that article :smile: