### PR TITLE
Fix bug in ValueObject.Equals

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/SeedWork/ValueObject.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/ValueObject.cs
@@ -30,8 +30,12 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             ValueObject other = (ValueObject)obj;
             IEnumerator<object> thisValues = GetAtomicValues().GetEnumerator();
             IEnumerator<object> otherValues = other.GetAtomicValues().GetEnumerator();
-            while (thisValues.MoveNext() && otherValues.MoveNext())
+            while (true)
             {
+                var thisValuesDone = !thisValues.MoveNext();
+                var otherValuesDone = !otherValues.MoveNext();
+                if (thisValuesDone || otherValuesDone) return thisValuesDone && otherValuesDone;
+
                 if (ReferenceEquals(thisValues.Current, null) ^ ReferenceEquals(otherValues.Current, null))
                 {
                     return false;
@@ -41,7 +45,6 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
                     return false;
                 }
             }
-            return !thisValues.MoveNext() && !otherValues.MoveNext();
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
This fixes the issue described here: https://github.com/dotnet/docs/issues/7477

The bug in ValueObject.Equals occurs when comparing two ValueObjects that have equal atomic values except that one of the two ValuesObjects has one atomic value more than the other. In that case ValueObject.Equals returned true even though the objects differ.
