### PR TITLE
Fix/1370 - Updated script related changes for helm 3.x and k8s 1.16.x

### DIFF
--- a/deploy/k8s/archived/README.md
+++ b/deploy/k8s/archived/README.md
@@ -1,0 +1,8 @@
+# Kubernetes deployment
+
+This folder contains the files required to deploy eShopOnContainers to a Kubernetes cluster.
+
+For more information see the following articles in the [wiki](https://github.com/dotnet-architecture/eShopOnContainers/wiki):
+
+- [Deploy to Local Kubernetes](https://github.com/dotnet-architecture/eShopOnContainers/wiki/Deploy-to-Local-Kubernetes)
+- [Deploy to Azure Kubernetes Service (AKS)](https://github.com/dotnet-architecture/eShopOnContainers/wiki/Deploy-to-Azure-Kubernetes-Service-(AKS))

--- a/deploy/k8s/archived/create-aks.ps1
+++ b/deploy/k8s/archived/create-aks.ps1
@@ -1,0 +1,50 @@
+﻿Param(
+    [parameter(Mandatory=$true)][string]$resourceGroupName,
+    [parameter(Mandatory=$true)][string]$location,
+    [parameter(Mandatory=$true)][string]$serviceName,
+    [parameter(Mandatory=$true)][string]$dnsNamePrefix,
+    [parameter(Mandatory=$false)][string]$registryName,
+    [parameter(Mandatory=$true)][bool]$createAcr=$true,
+    [parameter(Mandatory=$false)][int]$nodeCount=3,
+    [parameter(Mandatory=$false)][string]$nodeVMSize="Standard_D2_v2",
+    [parameter(Mandatory=$false)][bool]$enableHttpApplicationAddon=$true,
+    [parameter(Mandatory=$false)][bool]$enableAzureMonitoring=$false,
+    [parameter(Mandatory=$false)][ValidateSet("VirtualMachineScaleSets","AvailabilitySet",IgnoreCase=$true)]$vmSetType="VirtualMachineScaleSets"
+)
+
+# Create resource group
+Write-Host "Creating Azure Resource Group..." -ForegroundColor Yellow
+az group create --name=$resourceGroupName --location=$location
+
+if ($createAcr -eq $true) {
+    # Create Azure Container Registry
+    if ([string]::IsNullOrEmpty($registryName)) {
+        $registryName=$serviceName
+    }
+    Write-Host "Creating Azure Container Registry named $registryName" -ForegroundColor Yellow
+    az acr create -n $registryName -g $resourceGroupName -l $location  --admin-enabled true --sku Basic
+}
+
+# Create kubernetes cluster in AKS
+Write-Host "Creating AKS $resourceGroupName/$serviceName" -ForegroundColor Yellow
+az aks create --resource-group=$resourceGroupName --name=$serviceName --dns-name-prefix=$dnsNamePrefix --generate-ssh-keys --node-count=$nodeCount --node-vm-size=$nodeVMSize --vm-set-type $vmSetType
+
+if ($enableHttpApplicationAddon) {
+    Write-Host "Enabling Http Applciation Routing in AKS $serviceName" -ForegroundColor Yellow
+    az aks enable-addons --resource-group $resourceGroupName --name $serviceName --addons http_application_routing
+}
+
+if ($enableAzureMonitoring) {
+    Write-Host "Enabling Azure Monitoring in AKS $serviceName" -ForegroundColor Yellow
+    az aks enable-addons --resource-group $resourceGroupName --name $serviceName --addons monitoring
+}
+
+# Retrieve kubernetes cluster configuration and save it under ~/.kube/config
+Write-Host "Getting Kubernetes config..." -ForegroundColor Yellow
+az aks get-credentials --resource-group=$resourceGroupName --name=$serviceName
+
+if ($createAcr -eq $true) {
+    # Show ACR credentials
+    Write-Host "ACR $registryName credentials:" -ForegroundColor Yellow
+    az acr credential show -n $registryName
+}

--- a/deploy/k8s/archived/dashboard-adminuser.yaml
+++ b/deploy/k8s/archived/dashboard-adminuser.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/deploy/k8s/archived/enable-tls.ps1
+++ b/deploy/k8s/archived/enable-tls.ps1
@@ -1,0 +1,20 @@
+Param (
+[parameter(Mandatory=$false)][string]$aksName="",
+[parameter(Mandatory=$false)][string]$aksRg=""
+)
+
+if ($aksName -and $aksRg) {
+
+    $aks=$(az aks show -n $aksName -g $aksRg -o json | ConvertFrom-Json)
+    if (-not $aks) {
+        Write-Host "AKS $aksName not found in RG $aksRg" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Switching kubectl context to $aksRg/$aksName" -ForegroundColor Yellow
+    az aks get-credentials -g $aksRg -n $aksName
+}
+
+Write-Host "Installing cert-manager on current cluster"
+
+kubectl apply  --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml --validate=false

--- a/deploy/k8s/archived/helm-rbac.yaml
+++ b/deploy/k8s/archived/helm-rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/deploy/k8s/archived/helm/aks-httpaddon-cfg.yaml
+++ b/deploy/k8s/archived/helm/aks-httpaddon-cfg.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+#    addonmanager.kubernetes.io/mode: Reconcile
+    app: addon-http-application-routing-ingress-nginx
+    kubernetes.io/cluster-service: "true"
+  name: addon-http-application-routing-nginx-configuration
+  namespace: kube-system
+data:
+  proxy-buffer-size: "128k"
+  proxy-buffers: "4 256k"

--- a/deploy/k8s/archived/helm/apigwmm/.helmignore
+++ b/deploy/k8s/archived/helm/apigwmm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/apigwmm/Chart.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: apigwmm
+version: 0.1.0

--- a/deploy/k8s/archived/helm/apigwmm/envoy.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/envoy.yaml
@@ -1,0 +1,75 @@
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: eshop_backend_route
+            virtual_hosts:
+            - name: eshop_backend
+              domains:
+              - "*"
+              routes:
+              - name: "m-short"
+                match:
+                  prefix: "/m/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/marketing-api/"
+                  cluster: marketing
+              - name: "m-long"
+                match:
+                  prefix: "/marketing-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: marketing
+          http_filters:
+          - name: envoy.router  
+          access_log:
+          - name: envoy.file_access_log
+            filter:
+              not_health_check_filter: {}          
+            config:
+              json_format:
+                time: "%START_TIME%"
+                protocol: "%PROTOCOL%"
+                duration: "%DURATION%"
+                request_method: "%REQ(:METHOD)%"  
+                request_host: "%REQ(HOST)%"  
+                path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" 
+                response_flags: "%RESPONSE_FLAGS%"
+                route_name: "%ROUTE_NAME%"
+                upstream_host: "%UPSTREAM_HOST%"
+                upstream_cluster: "%UPSTREAM_CLUSTER%"
+                upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"    
+              path: "/tmp/access.log"                 
+  clusters:
+  - name: marketing
+    connect_timeout: 0.25s
+    type: logical_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: marketing-api
+        port_value: 80
+  - name: locations
+    connect_timeout: 0.25s
+    type: logical_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: locations-api
+        port_value: 80

--- a/deploy/k8s/archived/helm/apigwmm/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/apigwmm/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop API Gateway for Mobile Marketing services installed
+----------------------------------------------------------

--- a/deploy/k8s/archived/helm/apigwmm/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/apigwmm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apigwmm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apigwmm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apigwmm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwmm/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/apigwmm/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwmm/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/templates/deployment.yaml
@@ -1,0 +1,110 @@
+{{- $name := include "apigwmm.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+{{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "apigwmm.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "apigwmm.name" . }}
+    chart: {{ template "apigwmm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "apigwmm.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "apigwmm.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}           
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ $envoycfgname }}
+          items:
+          - key: envoy.yaml
+            path: envoy.yaml    
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}          
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: config
+            mountPath: {{ .Values.envoy.configPath }}          
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: admin
+              containerPort: 8001
+              protocol: TCP              
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/apigwmm/templates/envoy-cm.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/templates/envoy-cm.yaml
@@ -1,0 +1,14 @@
+{{- $name := include "apigwmm.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "envoy-{{ $name }}"
+  labels:
+    app: {{ template "apigwmm.name" . }}
+    chart: {{ template "apigwmm.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{ (.Files.Glob "envoy.yaml").AsConfig  | indent 2 }}
+

--- a/deploy/k8s/archived/helm/apigwmm/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.mobilemarketingapigw -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "apigwmm.fullname" . }}
+  labels:
+    app: {{ template "apigwmm.name" . }}
+    chart: {{ template "apigwmm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts  }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/apigwmm/templates/service.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.mobilemarketingapigw }}
+  labels:
+    app: {{ template "apigwmm.name" . }}
+    chart: {{ template "apigwmm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin    
+  selector:
+    app: {{ template "apigwmm.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/apigwmm/values.yaml
+++ b/deploy/k8s/archived/helm/apigwmm/values.yaml
@@ -1,0 +1,45 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /mobilemarketingapigw
+
+image:
+  repository: envoyproxy/envoy
+  tag: v1.11.1
+
+service:
+  type: ClusterIP
+  port: 80
+  adminPort: 8001  
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    ingress.kubernetes.io/rewrite-target: "/"
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env: {}
+
+envoy:
+  configPath: /etc/envoy
+
+probes:
+  liveness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    port: 8001
+  readiness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 60
+    port: 8001

--- a/deploy/k8s/archived/helm/apigwms/.helmignore
+++ b/deploy/k8s/archived/helm/apigwms/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/apigwms/Chart.yaml
+++ b/deploy/k8s/archived/helm/apigwms/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: apigwms
+version: 0.1.0

--- a/deploy/k8s/archived/helm/apigwms/envoy.yaml
+++ b/deploy/k8s/archived/helm/apigwms/envoy.yaml
@@ -1,0 +1,139 @@
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: eshop_backend_route
+            virtual_hosts:
+            - name: eshop_backend
+              domains:
+              - "*"
+              routes:
+              - name: "c-short"
+                match:
+                  prefix: "/c/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/catalog-api/"
+                  cluster: catalog
+              - name: "c-long"
+                match:
+                  prefix: "/catalog-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: catalog
+              - name: "o-short"
+                match:
+                  prefix: "/o/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/ordering-api/"
+                  cluster: ordering
+              - name: "o-long"
+                match:
+                  prefix: "/ordering-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: ordering
+              - name: "h-long"
+                match:
+                  prefix: "/hub/notificationhub"
+                route:
+                  auto_host_rewrite: true
+                  cluster: signalr-hub
+                  timeout: 300s
+              - name: "b-short"
+                match:
+                  prefix: "/b/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/basket-api/"
+                  cluster: basket
+              - name: "b-long"
+                match:
+                  prefix: "/basket-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: basket
+              - name: "agg"
+                match:
+                  prefix: "/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/"
+                  cluster: shoppingagg
+          http_filters:
+          - name: envoy.router
+          access_log:
+          - name: envoy.file_access_log
+            filter:
+              not_health_check_filter: {}
+            config:
+              json_format:
+                time: "%START_TIME%"
+                protocol: "%PROTOCOL%"
+                duration: "%DURATION%"
+                request_method: "%REQ(:METHOD)%"
+                request_host: "%REQ(HOST)%"
+                path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                response_flags: "%RESPONSE_FLAGS%"
+                route_name: "%ROUTE_NAME%"
+                upstream_host: "%UPSTREAM_HOST%"
+                upstream_cluster: "%UPSTREAM_CLUSTER%"
+                upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              path: "/tmp/access.log"
+  clusters:
+  - name: shoppingagg
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: webshoppingagg
+        port_value: 80
+  - name: catalog
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: catalog-api
+        port_value: 80
+  - name: basket
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: basket-api
+        port_value: 80
+  - name: ordering
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: ordering-api
+        port_value: 80
+  - name: signalr-hub
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: ordering-signalrhub
+        port_value: 80

--- a/deploy/k8s/archived/helm/apigwms/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/apigwms/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop API Gateway for Mobile Shopping services installed
+--------------------------------------------------------

--- a/deploy/k8s/archived/helm/apigwms/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/apigwms/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apigwms.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apigwms.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apigwms.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwms/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/apigwms/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwms/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/apigwms/templates/deployment.yaml
@@ -1,0 +1,110 @@
+{{- $name := include "apigwms.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+{{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "apigwms.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "apigwms.name" . }}
+    chart: {{ template "apigwms.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "apigwms.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "apigwms.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}           
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ $envoycfgname }}
+          items:
+          - key: envoy.yaml
+            path: envoy.yaml
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: config
+            mountPath: {{ .Values.envoy.configPath }}         
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: admin
+              containerPort: 8001
+              protocol: TCP              
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/apigwms/templates/envoy-cm.yaml
+++ b/deploy/k8s/archived/helm/apigwms/templates/envoy-cm.yaml
@@ -1,0 +1,14 @@
+{{- $name := include "apigwms.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "envoy-{{ $name }}"
+  labels:
+    app: {{ template "apigwms.name" . }}
+    chart: {{ template "apigwms.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
+

--- a/deploy/k8s/archived/helm/apigwms/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/apigwms/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.mobileshoppingapigw -}}
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "apigwms.fullname" . }}
+  labels:
+    app: {{ template "apigwms.name" . }}
+    chart: {{ template "apigwms.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/apigwms/templates/service.yaml
+++ b/deploy/k8s/archived/helm/apigwms/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.mobileshoppingapigw }}
+  labels:
+    app: {{ template "apigwms.name" . }}
+    chart: {{ template "apigwms.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin     
+  selector:
+    app: {{ template "apigwms.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/apigwms/values.yaml
+++ b/deploy/k8s/archived/helm/apigwms/values.yaml
@@ -1,0 +1,45 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /mobileshoppingapigw
+
+image:
+  repository: envoyproxy/envoy
+  tag: v1.11.1
+
+service:
+  type: ClusterIP
+  port: 80
+  adminPort: 8001  
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    ingress.kubernetes.io/rewrite-target: "/"
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env: {}
+
+envoy:
+  configPath: /etc/envoy
+
+probes:
+  liveness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    port: 8001
+  readiness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 60
+    port: 8001

--- a/deploy/k8s/archived/helm/apigwwm/.helmignore
+++ b/deploy/k8s/archived/helm/apigwwm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/apigwwm/Chart.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: apigwwm
+version: 0.1.0

--- a/deploy/k8s/archived/helm/apigwwm/envoy.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/envoy.yaml
@@ -1,0 +1,75 @@
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: eshop_backend_route
+            virtual_hosts:
+            - name: eshop_backend
+              domains:
+              - "*"
+              routes:
+              - name: "m-short"
+                match:
+                  prefix: "/m/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/marketing-api/"
+                  cluster: marketing
+              - name: "m-long"
+                match:
+                  prefix: "/marketing-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: marketing
+          http_filters:
+          - name: envoy.router      
+          access_log:
+          - name: envoy.file_access_log
+            filter:
+              not_health_check_filter: {}          
+            config:
+              json_format:
+                time: "%START_TIME%"
+                protocol: "%PROTOCOL%"
+                duration: "%DURATION%"
+                request_method: "%REQ(:METHOD)%"  
+                request_host: "%REQ(HOST)%"  
+                path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" 
+                response_flags: "%RESPONSE_FLAGS%"
+                route_name: "%ROUTE_NAME%"
+                upstream_host: "%UPSTREAM_HOST%"
+                upstream_cluster: "%UPSTREAM_CLUSTER%"
+                upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"     
+              path: "/tmp/access.log"
+  clusters:
+  - name: marketing
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: marketing-api
+        port_value: 80
+  - name: locations
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: locations-api
+        port_value: 80

--- a/deploy/k8s/archived/helm/apigwwm/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/apigwwm/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop API Gateway for Web Marketing services installed
+------------------------------------------------------

--- a/deploy/k8s/archived/helm/apigwwm/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/apigwwm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apigwwm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apigwwm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apigwwm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwwm/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/apigwwm/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwwm/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/templates/deployment.yaml
@@ -1,0 +1,110 @@
+{{- $name := include "apigwwm.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+{{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "apigwwm.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "apigwwm.name" . }}
+    chart: {{ template "apigwwm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "apigwwm.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "apigwwm.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}           
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ $envoycfgname }}
+          items:
+          - key: envoy.yaml
+            path: envoy.yaml
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: config
+            mountPath: {{ .Values.envoy.configPath }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: admin
+              containerPort: 8001
+              protocol: TCP              
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/apigwwm/templates/envoy-cm.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/templates/envoy-cm.yaml
@@ -1,0 +1,14 @@
+{{- $name := include "apigwwm.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "envoy-{{ $name }}"
+  labels:
+    app: {{ template "apigwwm.name" . }}
+    chart: {{ template "apigwwm.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 -}} 
+

--- a/deploy/k8s/archived/helm/apigwwm/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.webmarketingapigw -}}
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "apigwwm.fullname" . }}
+  labels:
+    app: {{ template "apigwwm.name" . }}
+    chart: {{ template "apigwwm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/apigwwm/templates/service.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.webmarketingapigw }}
+  labels:
+    app: {{ template "apigwwm.name" . }}
+    chart: {{ template "apigwwm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin      
+  selector:
+    app: {{ template "apigwwm.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/apigwwm/values.yaml
+++ b/deploy/k8s/archived/helm/apigwwm/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webmarketingapigw
+
+image:
+  repository: envoyproxy/envoy
+  tag: v1.11.1
+
+service:
+  type: ClusterIP
+  port: 80
+  adminPort: 8001  
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    ingress.kubernetes.io/rewrite-target: "/"
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env: {}
+
+envoy:
+  configPath: /etc/envoy
+
+probes:
+  liveness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    port: 8001
+  readiness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 60
+    port: 8001

--- a/deploy/k8s/archived/helm/apigwws/.helmignore
+++ b/deploy/k8s/archived/helm/apigwws/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/apigwws/Chart.yaml
+++ b/deploy/k8s/archived/helm/apigwws/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: apigwws
+version: 0.1.0

--- a/deploy/k8s/archived/helm/apigwws/envoy.yaml
+++ b/deploy/k8s/archived/helm/apigwws/envoy.yaml
@@ -1,0 +1,139 @@
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: eshop_backend_route
+            virtual_hosts:
+            - name: eshop_backend
+              domains:
+              - "*"
+              routes:
+              - name: "c-short"
+                match:
+                  prefix: "/c/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/catalog-api/"
+                  cluster: catalog
+              - name: "c-long"
+                match:
+                  prefix: "/catalog-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: catalog
+              - name: "o-short"
+                match:
+                  prefix: "/o/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/ordering-api/"
+                  cluster: ordering
+              - name: "o-long"
+                match:
+                  prefix: "/ordering-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: ordering
+              - name: "h-long"
+                match:
+                  prefix: "/hub/notificationhub"
+                route:
+                  auto_host_rewrite: true
+                  cluster: signalr-hub
+                  timeout: 300s
+              - name: "b-short"
+                match:
+                  prefix: "/b/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/basket-api/"
+                  cluster: basket
+              - name: "b-long"
+                match:
+                  prefix: "/basket-api/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: basket
+              - name: "agg"
+                match:
+                  prefix: "/"
+                route:
+                  auto_host_rewrite: true
+                  prefix_rewrite: "/"
+                  cluster: shoppingagg
+          http_filters:
+          - name: envoy.router
+          access_log:
+          - name: envoy.file_access_log
+            filter:
+              not_health_check_filter: {}
+            config:
+              json_format:
+                time: "%START_TIME%"
+                protocol: "%PROTOCOL%"
+                duration: "%DURATION%"
+                request_method: "%REQ(:METHOD)%"
+                request_host: "%REQ(HOST)%"
+                path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                response_flags: "%RESPONSE_FLAGS%"
+                route_name: "%ROUTE_NAME%"
+                upstream_host: "%UPSTREAM_HOST%"
+                upstream_cluster: "%UPSTREAM_CLUSTER%"
+                upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+              path: "/tmp/access.log"
+  clusters:
+  - name: shoppingagg
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: webshoppingagg
+        port_value: 80
+  - name: catalog
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: catalog-api
+        port_value: 80
+  - name: basket
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: basket-api
+        port_value: 80
+  - name: ordering
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: ordering-api
+        port_value: 80
+  - name: signalr-hub
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: ordering-signalrhub
+        port_value: 80

--- a/deploy/k8s/archived/helm/apigwws/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/apigwws/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop API Gateway for Web Shopping services installed
+-----------------------------------------------------

--- a/deploy/k8s/archived/helm/apigwws/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/apigwws/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apigwws.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apigwws.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apigwws.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwws/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/apigwws/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/apigwws/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/apigwws/templates/deployment.yaml
@@ -1,0 +1,109 @@
+{{- $name := include "apigwws.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+{{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "apigwws.fullname" . }}
+  labels:
+    app: {{ template "apigwws.name" . }}
+    chart: {{ template "apigwws.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "apigwws.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "apigwws.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}           
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ $envoycfgname }}
+          items:
+          - key: envoy.yaml
+            path: envoy.yaml
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}        
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+          - name: config
+            mountPath: {{ .Values.envoy.configPath }}      
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: admin
+              containerPort: 8001
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/apigwws/templates/envoy-cm.yaml
+++ b/deploy/k8s/archived/helm/apigwws/templates/envoy-cm.yaml
@@ -1,0 +1,14 @@
+{{- $name := include "apigwws.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "envoy-{{ $name }}"
+  labels:
+    app: {{ template "apigwws.name" . }}
+    chart: {{ template "apigwws.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
+

--- a/deploy/k8s/archived/helm/apigwws/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/apigwws/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.webshoppingapigw -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "apigwws.fullname" . }}
+  labels:
+    app: {{ template "apigwws.name" . }}
+    chart: {{ template "apigwws.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/apigwws/templates/service.yaml
+++ b/deploy/k8s/archived/helm/apigwws/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.webshoppingapigw }}
+  labels:
+    app: {{ template "apigwws.name" . }}
+    chart: {{ template "apigwws.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
+  selector:
+    app: {{ template "apigwws.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/apigwws/values.yaml
+++ b/deploy/k8s/archived/helm/apigwws/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webshoppingapigw
+
+image:
+  repository: envoyproxy/envoy
+  tag: v1.11.1
+
+service:
+  type: ClusterIP
+  port: 80
+  adminPort: 8001
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    ingress.kubernetes.io/rewrite-target: "/"
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env: {}
+
+envoy:
+  configPath: /etc/envoy
+
+probes:
+  liveness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    port: 8001
+  readiness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 60
+    port: 8001

--- a/deploy/k8s/archived/helm/app.yaml
+++ b/deploy/k8s/archived/helm/app.yaml
@@ -1,0 +1,46 @@
+# This helm values file defines app-based settings
+# Charts use those values, so this file **MUST** be included in all chart releases
+
+app:                                                    # app global settings
+  name: "my-eshop"                                      # Override for custom app name
+  ingress:                                              # ingress related settings
+    entries:
+      basket: basket-api                                # ingress entry for basket api
+      catalog: catalog-api                              # ingress entry for catalog api
+      ordering: ordering-api                            # ingress entry for ordering api
+      identity: identity                                # ingress entry for identity api
+      mvc: webmvc                                       # ingress entry for web mvc
+      spa: ""                                           # ingress entry for web spa
+      status: webstatus                                 # ingress entry for web status
+      webshoppingapigw: webshoppingapigw                # ingress entry for web shopping Agw
+      webmarketingapigw: webmarketingapigw              # ingress entry for web mkg Agw
+      mobilemarketingapigw: mobilemarketingapigw        # ingress entry for mobile mkg Agw
+      mobileshoppingapigw: mobileshoppingapigw          # ingress entry for mobile shopping Agw
+      webshoppingagg: webshoppingagg                    # ingress entry for web shopping aggregator
+      mobileshoppingagg: mobileshoppingagg              # ingress entry for mobile shopping aggregator
+      payment: payment-api                              # ingress entry for payment api
+      locations: locations-api                          # ingress entry for locations api
+      marketing: marketing-api                          # ingress entry for marketing api
+      webhooks: webhooks-api                            # ingress entry for webhooks api
+      webhooksweb: webhooks-web                         # ingress entry for webhooks web demo client
+  svc:
+      basket: basket-api                                # service name for basket api
+      catalog: catalog-api                              # service name for catalog api
+      ordering: ordering-api                            # service name for ordering api
+      orderingbackgroundtasks: ordering-backgroundtasks # service name for orderingbackgroundtasks
+      orderingsignalrhub: ordering-signalrhub           # service name for orderingsignalrhub
+      identity: identity-api                            # service name for identity api
+      mvc: webmvc                                       # service name for web mvc
+      spa: webspa                                       # service name for web spa
+      status: webstatus                                 # service name for web status
+      webshoppingapigw: webshoppingapigw                # service name for web shopping Agw
+      webmarketingapigw: webmarketingapigw              # service name for web mkg Agw
+      mobilemarketingapigw: mobilemarketingapigw        # service name for mobile mkg Agw
+      mobileshoppingapigw: mobileshoppingapigw          # service name for mobile shopping Agw
+      webshoppingagg: webshoppingagg                    # service name for web shopping aggregator
+      mobileshoppingagg: mobileshoppingagg              # service name for mobile shopping aggregator
+      payment: payment-api                              # service name for payment api
+      locations: locations-api                          # service name for locations api
+      marketing: marketing-api                          # service name for marketing ap
+      webhooks: webhooks-api                            # service name for webhooks api
+      webhooksweb: webhooks-client                      # service name for webhooks web

--- a/deploy/k8s/archived/helm/basket-api/.helmignore
+++ b/deploy/k8s/archived/helm/basket-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/basket-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/basket-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: basket-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/basket-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/basket-api/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Basket API installed.
+--------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "basket-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/basket-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/basket-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "basket-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "basket-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "basket-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/basket-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/basket-api/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/basket-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/basket-api/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- $name := include "basket-api.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "basket-api.name" . }}
+    chart: {{ template "basket-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  basket__ConnectionString: {{ .Values.inf.redis.basket.constr }}
+  urls__IdentityUrl: http://{{ .Values.app.svc.identity }}
+  basket__EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/archived/helm/basket-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/basket-api/templates/deployment.yaml
@@ -1,0 +1,99 @@
+{{- $name := include "basket-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "basket-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "basket-api.name" . }}
+    chart: {{ template "basket-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "basket-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "basket-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}        
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet: 
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}        
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: grpc
+              containerPort: 81
+              protocol: TCP                
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/basket-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/basket-api/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.basket }}
+  labels:
+    app: {{ template "basket-api.name" . }}
+    chart: {{ template "basket-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app: {{ template "basket-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/basket-api/values.yaml
+++ b/deploy/k8s/archived/helm/basket-api/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /basket-api
+
+image:
+  repository: eshop/basket.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  grpcPort: 81  
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ConnectionString
+      key: basket__ConnectionString
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+    - name: UseLoadTest
+      key: basket__EnableLoadTest
+  # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: PORT
+      value: "80"
+    - name: GRPC_PORT
+      value: "81"      
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80
+
+ingress:
+  enabled: false

--- a/deploy/k8s/archived/helm/basket-data/.helmignore
+++ b/deploy/k8s/archived/helm/basket-data/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/basket-data/Chart.yaml
+++ b/deploy/k8s/archived/helm/basket-data/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: basket-data
+version: 0.1.0

--- a/deploy/k8s/archived/helm/basket-data/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/basket-data/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Redis for keystore data installed
+----------------------------------------
+
+Redis is not directly exposed outside cluster. If need to access it from outside use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "basket-data.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/basket-data/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/basket-data/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "basket-data.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "basket-data.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "basket-data.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/basket-data/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/basket-data/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "basket-data.fullname" . }}
+  labels:
+    app: {{ template "basket-data.name" . }}
+    chart: {{ template "basket-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "basket-data.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "basket-data.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 6379
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deploy/k8s/archived/helm/basket-data/templates/service.yaml
+++ b/deploy/k8s/archived/helm/basket-data/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.inf.redis.basket.svc }}
+  labels:
+    app: {{ template "basket-data.name" . }}
+    chart: {{ template "basket-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "basket-data.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/basket-data/values.yaml
+++ b/deploy/k8s/archived/helm/basket-data/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: redis
+  tag: 4.0.10
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 6379
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/k8s/archived/helm/catalog-api/.helmignore
+++ b/deploy/k8s/archived/helm/catalog-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/catalog-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/catalog-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: catalog-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/catalog-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/catalog-api/templates/NOTES.txt
@@ -1,0 +1,9 @@
+eShop Catalog API installed.
+----------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "catalog-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80
+

--- a/deploy/k8s/archived/helm/catalog-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/catalog-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "catalog-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "catalog-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "catalog-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/catalog-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/catalog-api/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/catalog-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/catalog-api/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- $name := include "catalog-api.fullname" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+{{- $webshoppingapigw := include "url-of" (list .Values.app.ingress.entries.webshoppingapigw .) -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "catalog-api.name" . }}
+    chart: {{ template "catalog-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  catalog__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.catalog.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  catalog__PicBaseUrl: {{ $protocol }}://{{ $webshoppingapigw }}/c/api/v1/catalog/items/[0]/pic/
+  catalog__AzureStorageEnabled: "{{ .Values.inf.misc.useAzureStorage }}"
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/archived/helm/catalog-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/catalog-api/templates/deployment.yaml
@@ -1,0 +1,99 @@
+{{- $name := include "catalog-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "catalog-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "catalog-api.name" . }}
+    chart: {{ template "catalog-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "catalog-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "catalog-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}               
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: grpc
+              containerPort: 81
+              protocol: TCP              
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/catalog-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/catalog-api/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.catalog }}
+  labels:
+    app: {{ template "catalog-api.name" . }}
+    chart: {{ template "catalog-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc     
+  selector:
+    app: {{ template "catalog-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/catalog-api/values.yaml
+++ b/deploy/k8s/archived/helm/catalog-api/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /catalog-api
+
+image:
+  repository: eshop/catalog.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  grpcPort: 81
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ConnectionString
+      key: catalog__ConnectionString
+    - name: PicBaseUrl
+      key: catalog__PicBaseUrl
+    - name: AzureStorageEnabled
+      key: catalog__AzureStorageEnabled
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: PORT
+      value: "80"
+    - name: GRPC_PORT
+      value: "81"
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80
+

--- a/deploy/k8s/archived/helm/deploy-all.ps1
+++ b/deploy/k8s/archived/helm/deploy-all.ps1
@@ -1,0 +1,149 @@
+Param(
+    [parameter(Mandatory=$false)][string]$registry,
+    [parameter(Mandatory=$false)][string]$dockerUser,
+    [parameter(Mandatory=$false)][string]$dockerPassword,
+    [parameter(Mandatory=$false)][string]$externalDns,
+    [parameter(Mandatory=$false)][string]$appName="eshop",
+    [parameter(Mandatory=$false)][bool]$deployInfrastructure=$true,
+    [parameter(Mandatory=$false)][bool]$deployCharts=$true,
+    [parameter(Mandatory=$false)][bool]$clean=$true,
+    [parameter(Mandatory=$false)][string]$aksName="",
+    [parameter(Mandatory=$false)][string]$aksRg="",
+    [parameter(Mandatory=$false)][string]$imageTag="latest",
+    [parameter(Mandatory=$false)][bool]$useLocalk8s=$false,
+    [parameter(Mandatory=$false)][bool]$useMesh=$false,
+    [parameter(Mandatory=$false)][string][ValidateSet('Always','IfNotPresent','Never', IgnoreCase=$false)]$imagePullPolicy="Always",
+    [parameter(Mandatory=$false)][string][ValidateSet('prod','staging','none','custom', IgnoreCase=$false)]$sslSupport = "none",
+    [parameter(Mandatory=$false)][string]$tlsSecretName = "eshop-tls-custom",
+    [parameter(Mandatory=$false)][string]$chartsToDeploy="*",
+    [parameter(Mandatory=$false)][string]$ingressMeshAnnotationsFile="ingress_values_linkerd.yaml"
+    )
+
+function Install-Chart  {
+    Param([string]$chart,[string]$initialOptions, [bool]$customRegistry)
+    $options=$initialOptions
+    if ($sslEnabled) {
+        $options = "$options --set ingress.tls[0].secretName=$tlsSecretName --set ingress.tls[0].hosts={$dns}" 
+        if ($sslSupport -ne "custom") {
+            $options = "$options --set inf.tls.issuer=$sslIssuer"
+        }
+    }
+    if ($customRegistry) {
+        $options = "$options --set inf.registry.server=$registry --set inf.registry.login=$dockerUser --set inf.registry.pwd=$dockerPassword --set inf.registry.secretName=eshop-docker-scret"
+    }
+    
+    if ($chart -ne "eshop-common" -or $customRegistry)  {       # eshop-common is ignored when no secret must be deployed        
+        $command = "install $options --name=$appName-$chart $chart"
+        Write-Host "Helm Command: helm $command" -ForegroundColor Gray
+        Invoke-Expression 'cmd /c "helm $command"'
+    }
+}
+
+$dns = $externalDns
+$sslEnabled=$false
+$sslIssuer=""
+
+if ($sslSupport -eq "staging") {
+    $sslEnabled=$true
+    $tlsSecretName="eshop-letsencrypt-staging"
+    $sslIssuer="letsencrypt-staging"
+}
+elseif ($sslSupport -eq "prod") {
+    $sslEnabled=$true
+    $tlsSecretName="eshop-letsencrypt-prod"
+    $sslIssuer="letsencrypt-prod"
+}
+elseif ($sslSupport -eq "custom") {
+    $sslEnabled=$true
+}
+
+$ingressValuesFile="ingress_values.yaml"
+
+if ($useLocalk8s -eq $true) {
+    $ingressValuesFile="ingress_values_dockerk8s.yaml"
+    $dns="localhost"
+}
+
+if ($externalDns -eq "aks") {
+    if  ([string]::IsNullOrEmpty($aksName) -or [string]::IsNullOrEmpty($aksRg)) {
+        Write-Host "Error: When using -dns aks, MUST set -aksName and -aksRg too." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Getting DNS of AKS of AKS $aksName (in resource group $aksRg)..." -ForegroundColor Green
+    $dns = $(az aks show -n $aksName  -g $aksRg --query addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName)
+    if ([string]::IsNullOrEmpty($dns)) {
+        Write-Host "Error getting DNS of AKS $aksName (in resource group $aksRg). Please ensure AKS has httpRouting enabled AND Azure CLI is logged & in version 2.0.37 or higher" -ForegroundColor Red
+        exit 1
+    }
+    $dns = $dns -replace '[\"]'
+    Write-Host "DNS base found is $dns. Will use $appName.$dns for the app!" -ForegroundColor Green
+    $dns = "$appName.$dns"
+}
+
+# Initialization & check commands
+if ([string]::IsNullOrEmpty($dns)) {
+    Write-Host "No DNS specified. Ingress resources will be bound to public ip" -ForegroundColor Yellow
+    if ($sslEnabled) {
+        Write-Host "Can't bound SSL to public IP. DNS is mandatory when using TLS" -ForegroundColor Red
+        exit 1
+    }
+}
+
+if ($useLocalk8s -and $sslEnabled) {
+    Write-Host "SSL can'be enabled on local K8s." -ForegroundColor Red
+    exit 1
+}
+
+if ($clean) {
+    Write-Host "Cleaning previous helm releases..." -ForegroundColor Green
+    helm delete --purge $(helm ls -q eshop) 
+    Write-Host "Previous releases deleted" -ForegroundColor Green
+}
+
+$useCustomRegistry=$false
+
+if (-not [string]::IsNullOrEmpty($registry)) {
+    $useCustomRegistry=$true
+    if ([string]::IsNullOrEmpty($dockerUser) -or [string]::IsNullOrEmpty($dockerPassword)) {
+        Write-Host "Error: Must use -dockerUser AND -dockerPassword if specifying custom registry" -ForegroundColor Red
+        exit 1
+    }
+}
+
+Write-Host "Begin eShopOnContainers installation using Helm" -ForegroundColor Green
+
+$infras = ("sql-data", "nosql-data", "rabbitmq", "keystore-data", "basket-data")
+$charts = ("eshop-common", "basket-api","catalog-api", "identity-api", "locations-api", "marketing-api", "mobileshoppingagg","ordering-api","ordering-backgroundtasks","ordering-signalrhub", "payment-api", "webmvc", "webshoppingagg", "webspa", "webstatus", "webhooks-api", "webhooks-web")
+$gateways = ("apigwmm", "apigwms", "apigwwm", "apigwws")
+
+if ($deployInfrastructure) {
+    foreach ($infra in $infras) {
+        Write-Host "Installing infrastructure: $infra" -ForegroundColor Green
+        helm install --values app.yaml --values inf.yaml --values $ingressValuesFile --set app.name=$appName --set inf.k8s.dns=$dns --set "ingress.hosts={$dns}" --name="$appName-$infra" $infra     
+    }
+}
+else {
+    Write-Host "eShopOnContainers infrastructure (bbdd, redis, ...) charts aren't installed (-deployCharts is false)" -ForegroundColor Yellow
+}
+
+if ($deployCharts) {
+    foreach ($chart in $charts) {
+        if ($chartsToDeploy -eq "*" -or $chartsToDeploy.Contains($chart)) {
+            Write-Host "Installing: $chart" -ForegroundColor Green
+            Install-Chart $chart "-f app.yaml --values inf.yaml -f $ingressValuesFile -f $ingressMeshAnnotationsFile --set app.name=$appName --set inf.k8s.dns=$dns --set ingress.hosts={$dns} --set image.tag=$imageTag --set image.pullPolicy=$imagePullPolicy --set inf.tls.enabled=$sslEnabled --set inf.mesh.enabled=$useMesh --set inf.k8s.local=$useLocalk8s" $useCustomRegistry
+        }
+    }
+
+    foreach ($chart in $gateways) {
+        if ($chartsToDeploy -eq "*" -or $chartsToDeploy.Contains($chart)) {
+            Write-Host "Installing Api Gateway Chart: $chart" -ForegroundColor Green
+            Install-Chart $chart "-f app.yaml -f inf.yaml -f $ingressValuesFile  --set app.name=$appName --set inf.k8s.dns=$dns  --set image.pullPolicy=$imagePullPolicy --set inf.mesh.enabled=$useMesh --set ingress.hosts={$dns} --set inf.tls.enabled=$sslEnabled" $false
+            
+        }
+    }
+}
+else {
+    Write-Host "eShopOnContainers non-infrastructure charts aren't installed (-deployCharts is false)" -ForegroundColor Yellow
+}
+
+Write-Host "helm charts installed." -ForegroundColor Green

--- a/deploy/k8s/archived/helm/deploy-all.sh
+++ b/deploy/k8s/archived/helm/deploy-all.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode
+set -euo pipefail
+
+usage()
+{
+  cat <<END
+deploy.sh: deploys the $app_name application to a Kubernetes cluster using Helm.
+Parameters:
+  --aks-name <AKS cluster name>
+    The name of the AKS cluster. Required when the registry (using the -r parameter) is set to "aks".
+  --aks-rg <AKS resource group>
+    The resource group for the AKS cluster. Required when the registry (using the -r parameter) is set to "aks".
+  -b | --build-solution
+    Force a solution build before deployment (default: false).
+  -d | --dns <dns or ip address> | --dns aks
+    Specifies the external DNS/ IP address of the Kubernetes cluster.
+    If 'aks' is set as value, the DNS value is retrieved from the AKS. --aks-name and --aks-rg are needed.
+    When --use-local-k8s is specified the external DNS is automatically set to localhost.
+  -h | --help
+    Displays this help text and exits the script.
+  --image-build
+    Build images (default is to not build all images).
+  --image-push
+    Upload images to the container registry (default is not pushing to the custom registry)
+  -n | --app-name <the name of the app>
+    Specifies the name of the application (default: eshop).
+  --namespace <namespace name>
+    Specifies the namespace name to deploy the app. If it doesn't exists it will be created (default: eshop).
+  -p | --docker-password <docker password>
+    The Docker password used to logon to the custom registry, supplied using the -r parameter.
+  -r | --registry <container registry>
+    Specifies the container registry to use (required), e.g. myregistry.azurecr.io.
+  --skip-clean
+    Do not clean the Kubernetes cluster (default is to clean the cluster).
+  --skip-infrastructure
+    Do not deploy infrastructure resources (like sql-data, no-sql or redis).
+    This is useful for production environments where infrastructure is hosted outside the Kubernetes cluster.
+  -t | --tag <docker image tag>
+    The tag used for the newly created docker images. Default: latest.
+  -u | --docker-username <docker username>
+    The Docker username used to logon to the custom registry, supplied using the -r parameter.
+  --use-local-k8s
+    Deploy to a locally installed Kubernetes (default: false).
+
+It is assumed that the Kubernetes cluster has been granted access to the container registry.
+If using AKS and ACR see link for more info: 
+https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-aks
+
+WARNING! THE SCRIPT WILL COMPLETELY DESTROY ALL DEPLOYMENTS AND SERVICES VISIBLE
+FROM THE CURRENT CONFIGURATION CONTEXT AND NAMESPACE.
+It is recommended that you check your selected namespace, 'eshop' by default, is already in use.
+Every deployment and service done in the namespace will be deleted.
+For more information see https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+
+END
+}
+
+app_name='eshop'
+aks_name=''
+aks_rg=''
+build_images=''
+clean='yes'
+build_solution=''
+container_registry=''
+docker_password=''
+docker_username=''
+dns=''
+image_tag='latest'
+push_images=''
+skip_infrastructure=''
+use_local_k8s=''
+namespace='eshop'
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --aks-name )
+      aks_name="$2"; shift 2;;
+    --aks-rg )
+      aks_rg="$2"; shift 2;;
+    -b | --build-solution )
+      build_solution='yes'; shift ;;
+    -d | --dns )
+      dns="$2"; shift 2;;
+    -h | --help )
+      usage; exit 1 ;;
+    -n | --app-name )
+      app_name="$2"; shift 2;;
+    -p | --docker-password )
+      docker_password="$2"; shift 2;;
+    -r | --registry )
+      container_registry="$2"; shift 2;;
+    --skip-clean )
+      clean=''; shift ;;
+    --image-build )
+      build_images='yes'; shift ;;
+    --image-push )
+      push_images='yes'; shift ;;
+    --skip-infrastructure )
+      skip_infrastructure='yes'; shift ;;
+    -t | --tag )
+      image_tag="$2"; shift 2;;  
+    -u | --docker-username )
+      docker_username="$2"; shift 2;;
+    --use-local-k8s )
+      use_local_k8s='yes'; shift ;;
+    --namespace )
+      namespace="$2"; shift 2;;
+    *)
+      echo "Unknown option $1"
+      usage; exit 2 ;;
+  esac
+done
+
+if [[ $build_solution ]]; then
+  echo "#################### Building $app_name solution ####################"
+  dotnet publish -o obj/Docker/publish ../../eShopOnContainers-ServicesAndWebApps.sln
+fi
+
+export TAG=$image_tag
+
+if [[ $build_images ]]; then
+  echo "#################### Building the $app_name Docker images ####################"
+  docker-compose -p ../.. -f ../../docker-compose.yml build
+
+  # Remove temporary images
+  docker rmi $(docker images -qf "dangling=true") 
+fi
+
+use_custom_registry=''
+
+if [[ -n $container_registry ]]; then 
+  echo "################ Log into custom registry $container_registry ##################"
+  use_custom_registry='yes'
+  if [[ -z $docker_username ]] || [[ -z $docker_password ]]; then
+    echo "Error: Must use -u (--docker-username) AND -p (--docker-password) if specifying custom registry"
+    exit 1
+  fi
+  docker login -u $docker_username -p $docker_password $container_registry
+fi
+
+if [[ $push_images ]]; then
+  echo "#################### Pushing images to the container registry ####################"
+  services=(basket.api catalog.api identity.api ordering.api marketing.api payment.api locations.api webmvc webspa webstatus)
+
+  if [[ -z "$(docker image ls -q --filter=reference=eshop/$service:$image_tag)" ]]; then
+    image_tag=linux-$image_tag
+  fi
+
+  for service in "${services[@]}"
+  do
+    echo "Pushing image for service $service..."
+    docker tag "eshop/$service:$image_tag" "$container_registry/$service:$image_tag"
+    docker push "$container_registry/$service:$image_tag"
+  done
+fi
+
+ingress_values_file="ingress_values.yaml"
+
+if [[ $use_local_k8s ]]; then
+  ingress_values_file="ingress_values_dockerk8s.yaml"
+  dns="localhost"
+fi
+
+if [[ $dns == "aks" ]]; then
+  echo "#################### Begin AKS discovery based on the --dns aks setting. ####################"
+  if [[ -z $aks_name ]] || [[ -z $aks_rg ]]; then
+    echo "Error: When using -dns aks, MUST set -aksName and -aksRg too."
+    echo ''
+    usage
+    exit 1
+  fi
+
+  echo "Getting AKS cluster $aks_name  AKS (in resource group $aks_rg)"
+  # JMESPath queries are case sensitive and httpapplicationrouting can be lowercase sometimes
+  jmespath_dnsqueries=(\
+    addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName \
+    addonProfiles.httpapplicationrouting.config.HTTPApplicationRoutingZoneName \
+  )
+  for q in "${jmespath_dnsqueries[@]}"
+  do
+    dns="$(az aks show -n $aks_name -g $aks_rg --query $q -o tsv)"
+    if [[ -n $dns ]]; then break; fi
+  done
+  if [[ -z $dns ]]; then
+    echo "Error: when getting DNS of AKS $aks_name (in resource group $aks_rg). Please ensure AKS has httpRouting enabled AND Azure CLI is logged in and is of version 2.0.37 or higher."
+    exit 1
+  fi
+  echo "DNS base found is $dns. Will use $aks_name.$dns for the app!"
+  dns="$aks_name.$dns"
+fi
+
+# Initialization & check commands
+if [[ -z $dns ]]; then
+  echo "No DNS specified. Ingress resources will be bound to public IP."
+fi
+
+if [[ $clean ]]; then
+  echo "Cleaning previous helm releases..."
+  if [[ -z $(helm ls -q --namespace $namespace) ]]; then
+    echo "No previous releases found"
+  else
+    helm delete --purge $(helm ls -q --namespace $namespace)
+    echo "Previous releases deleted"
+    waitsecs=10; while [ $waitsecs -gt 0 ]; do echo -ne "$waitsecs\033[0K\r"; sleep 1; : $((waitsecs--)); done
+  fi
+fi
+
+echo "#################### Begin $app_name installation using Helm ####################"
+infras=(sql-data nosql-data rabbitmq keystore-data basket-data)
+charts=(eshop-common apigwmm apigwms apigwwm apigwws basket-api catalog-api identity-api locations-api marketing-api mobileshoppingagg ordering-api ordering-backgroundtasks ordering-signalrhub payment-api webmvc webshoppingagg webspa webstatus webhooks-api webhooks-web)
+
+if [[ !$skip_infrastructure ]]; then
+  for infra in "${infras[@]}"
+  do
+    echo "Installing infrastructure: $infra"
+    helm install --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --name="$app_name-$infra" $infra     
+  done  
+fi
+
+for chart in "${charts[@]}"
+do
+    echo "Installing: $chart"
+    if [[ $use_custom_registry ]]; then 
+      helm install --namespace $namespace --set "ingress.hosts={$dns}" --set inf.registry.server=$container_registry --set inf.registry.login=$docker_username --set inf.registry.pwd=$docker_password --set inf.registry.secretName=eshop-docker-scret --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always --name="$app_name-$chart" $chart 
+    elif [[ $chart != "eshop-common" ]]; then  # eshop-common is ignored when no secret must be deployed
+      helm install --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always --name="$app_name-$chart" $chart 
+    fi
+done
+
+echo "FINISHED: Helm charts installed."

--- a/deploy/k8s/archived/helm/eshop-common/.helmignore
+++ b/deploy/k8s/archived/helm/eshop-common/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/eshop-common/Chart.yaml
+++ b/deploy/k8s/archived/helm/eshop-common/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: eshop-common
+version: 0.1.0

--- a/deploy/k8s/archived/helm/eshop-common/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/eshop-common/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Common eShop resources installed:
+
+{{- if .Values.inf.registry -}}
+* Docker registry secret ({{ .Values.inf.registry.secretName }})
+{{- end -}}
+
++++ Done +++

--- a/deploy/k8s/archived/helm/eshop-common/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/eshop-common/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eshop-common.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eshop-common.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eshop-common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/eshop-common/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/eshop-common/templates/_names.tpl
@@ -1,0 +1,3 @@
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.inf.registry.server (printf "%s:%s" .Values.inf.registry.login .Values.inf.registry.pwd | b64enc) | b64enc }}
+{{- end }}

--- a/deploy/k8s/archived/helm/eshop-common/templates/secret.yaml
+++ b/deploy/k8s/archived/helm/eshop-common/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.inf.registry -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.inf.registry.secretName }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end -}}

--- a/deploy/k8s/archived/helm/identity-api/.helmignore
+++ b/deploy/k8s/archived/helm/identity-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/identity-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/identity-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: identity-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/identity-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/identity-api/templates/NOTES.txt
@@ -1,0 +1,4 @@
+eShop Identity API installed.
+-----------------------------
+
+Access this API through ingress.

--- a/deploy/k8s/archived/helm/identity-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/identity-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "identity-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "identity-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "identity-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/identity-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/identity-api/templates/_names.tpl
@@ -1,0 +1,51 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/identity-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/identity-api/templates/configmap.yaml
@@ -1,0 +1,39 @@
+{{- $name := include "identity-api.fullname" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+{{- $mvc_url := include "url-of" (list .Values.app.ingress.entries.mvc  .) -}}
+{{- $spa_url := include "url-of" (list .Values.app.ingress.entries.spa .) -}}
+{{- $locations_url := include "url-of" (list .Values.app.ingress.entries.locations .) -}}
+{{- $marketing_url := include "url-of" (list .Values.app.ingress.entries.marketing .) -}}
+{{- $basket_url := include "url-of" (list .Values.app.ingress.entries.basket .) -}}
+{{- $ordering_url := include "url-of" (list .Values.app.ingress.entries.ordering .) -}}
+{{- $mobileshoppingagg := include "url-of" (list .Values.app.ingress.entries.mobileshoppingagg .) -}}
+{{- $webhoppingagg := include "url-of" (list .Values.app.ingress.entries.webshoppingagg .) -}}
+{{- $xamarincallback := include "url-of" (list "xamarincallback" .) -}}
+{{- $webhooks_url := include "url-of" (list .Values.app.ingress.entries.webhooks .) -}}
+{{- $webhooksweb_url := include "url-of" (list .Values.app.ingress.entries.webhooksweb .) -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "identity-api.name" . }}
+    chart: {{ template "identity-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  identity__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.identity.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  identity__keystore: {{ .Values.inf.redis.keystore.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  mvc_e: http://{{ $mvc_url }}
+  spa_e: http://{{ $spa_url }}
+  locations_e: http://{{ $locations_url }}
+  marketing_e: http://{{ $marketing_url }}
+  basket_e: http://{{ $basket_url }}
+  ordering_e: http://{{ $ordering_url }}
+  mobileshoppingagg_e: http://{{ $mobileshoppingagg }}
+  webshoppingagg_e: http://{{ $webhoppingagg }}
+  xamarin_callback_e: http://{{ $xamarincallback }}
+  webhooksapi_e:  http://{{ $webhooks_url }}
+  webhooksweb_e: http://{{ $webhooksweb_url }}
+  enableDevspaces: "{{ .Values.enableDevspaces }}"

--- a/deploy/k8s/archived/helm/identity-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/identity-api/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $name := include "identity-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "identity-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "identity-api.name" . }}
+    chart: {{ template "identity-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "identity-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "identity-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}           
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/identity-api/templates/ingress-dockerk8s.yaml
+++ b/deploy/k8s/archived/helm/identity-api/templates/ingress-dockerk8s.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- if .Values.inf.k8s.local -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.identity }}
+{{- $name := include "identity-api.fullname" . -}} 
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $name }}-local
+  labels:
+    app: {{ template "identity-api.name" . }}
+    chart: {{ template "identity-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}    
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {{ $serviceName }}
+          servicePort: http
+        path: {{ $ingressPath }}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/identity-api/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/identity-api/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.identity }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "identity-api.fullname" . }}
+  labels:
+    app: {{ template "identity-api.name" . }}
+    chart: {{ template "identity-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/identity-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/identity-api/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.identity }}
+  labels:
+    app: {{ template "identity-api.name" . }}
+    chart: {{ template "identity-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "identity-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/identity-api/values.yaml
+++ b/deploy/k8s/archived/helm/identity-api/values.yaml
@@ -1,0 +1,84 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /identity
+
+image:
+  repository: eshop/identity.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env:
+  urls:
+  configmap:
+    - name: ConnectionString
+      key: identity__ConnectionString
+    - name: DPConnectionString
+      key: identity__keystore
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: MvcClient
+      key: mvc_e
+    - name: SpaClient
+      key: spa_e
+    - name: LocationApiClient
+      key: locations_e
+    - name: MarketingApiClient
+      key: marketing_e
+    - name: BasketApiClient
+      key: basket_e
+    - name: OrderingApiClient
+      key: ordering_e
+    - name: MobileShoppingAggClient
+      key: mobileshoppingagg_e
+    - name: WebShoppingAggClient
+      key: webshoppingagg_e
+    - name: XamarinCallback
+      key: xamarin_callback_e
+    - name: WebhooksApiClient
+      key: webhooksapi_e
+    - name: WebhooksWebClient
+      key: webhooksweb_e
+    - name: EnableDevspaces
+      key: enableDevspaces
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      value: 'True'
+
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80
+
+enableDevspaces: "false"

--- a/deploy/k8s/archived/helm/inf.yaml
+++ b/deploy/k8s/archived/helm/inf.yaml
@@ -1,0 +1,56 @@
+# This helm values file defines all infrastructure used by eShopOnContainers.
+# It is used on all charts, so ** MUST BE INCLUDED ** on every deployment
+
+inf:
+  mesh:
+    enabled: false          # True to enable Linkerd (set by deploy-all.ps1)
+  tls:
+    enabled: false          # True to enable TLS (set by deploy-all.ps1)
+    issuer: ""              # cert-manager issuer to use for retrieving certs (set by deploy-all.ps1)
+  sql:                      # inf.sql defines the sql server databases & logins
+#    host:  my-sql-server   # Uncomment to specify a custom sql-server to be used. By default "sql-data-<appname>" will be used  
+    common:
+      user: sa              # SQL user
+      pwd: Pass@word        # SQL pwd
+      pid: Developer
+    catalog:                # inf.sql.catalog: settings for the catalog-api sql (user, pwd, db)
+      db: CatalogDb         # Catalog API SQL db name
+    ordering:               # inf.sql.ordering: settings for the ordering-api sql (user, pwd, db)
+      db: OrderingDb        # Ordering API SQL db name
+    identity:
+      db: IdentityDb        # Ordering API SQL db name
+    marketing:
+      db: MarketingDb       # Marketing API SQL db name
+    webhooks:
+      db: WebhooksDb        # Webhooks DB
+  mongo:
+#    host: my-nosql-data    # Uncomment to use specify custom mongo host. By default nosql-data is used
+    locations:
+      database: LocationsDb
+    marketing:
+      database: MarketingDb
+  redis:                    # inf.redis defines the redis' connection strings
+    basket:     
+      svc: basket-data      # Name of k8s svc for basket redis     
+      constr: basket-data   # Connection string to Redis used by Basket API
+    keystore:
+      svc: keystore-data    # Name of k8s svc for keystore-data redis
+      constr: keystore-data # Connection string to Redis used as a Keystore (by Identity API)
+  eventbus:
+    svc: rabbitmq           # Name of k8s svc for rabbitmq
+    constr: rabbitmq        # Event bus connection string
+    useAzure: false         # true if use Azure Service Bus. False if RabbitMQ
+  appinsights:
+      key: ""               # App insights to use
+  k8s:                      # inf.k8s defines Kubernetes cluster global config
+    dns:  ""                # k8s external  DNS. This value or ip value MUST BE PROVIDED
+    local: false            # True when deploying on "local K8s" provided by Docker Desktop.
+  misc:                     # inf.misc contains miscellaneous configuration related to infrastructure
+    useLoadTest: false      # If running under loading test or not
+    useAzureStorage: false  # If catalog api uses azure storage or not
+#  registry:                # Uncomment "registry" to specify registry secret
+#    secretName:            # secretName is the name of the secret inside k8s   
+#    server:                # Registry login server
+#    login:                 # User login
+#    pwd:                   # User pwd
+

--- a/deploy/k8s/archived/helm/ingress_values.yaml
+++ b/deploy/k8s/archived/helm/ingress_values.yaml
@@ -1,0 +1,8 @@
+# This file contains common ingress annotations when using AKS with Http Application Routing
+
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+    ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+

--- a/deploy/k8s/archived/helm/ingress_values_dockerk8s.yaml
+++ b/deploy/k8s/archived/helm/ingress_values_dockerk8s.yaml
@@ -1,0 +1,7 @@
+# This file contains common ingress annotations when using Kubernetes included in Docker Desktop
+
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"

--- a/deploy/k8s/archived/helm/ingress_values_linkerd.yaml
+++ b/deploy/k8s/archived/helm/ingress_values_linkerd.yaml
@@ -1,0 +1,16 @@
+# This file contains extra annotations to make Linkerd work with ingress.
+# ingress.mesh.annotations are inserted into ingress.annotations of the resource being generated, if mesh is deployed
+#
+# It is designed to work with NGINX ingress controller or the Http Application Routing
+#
+# Check https://linkerd.io/2/tasks/using-ingress/ for more info or other ingress controllers
+#
+# If using your custom file, use -ingressMeshAnnotationsFile parameter in deploy-all.ps1
+
+ingress:
+  mesh:
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+        proxy_hide_header l5d-remote-ip;
+        proxy_hide_header l5d-server-id;

--- a/deploy/k8s/archived/helm/keystore-data/.helmignore
+++ b/deploy/k8s/archived/helm/keystore-data/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/keystore-data/Chart.yaml
+++ b/deploy/k8s/archived/helm/keystore-data/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: keystore-data
+version: 0.1.0

--- a/deploy/k8s/archived/helm/keystore-data/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/keystore-data/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Redis for keystore data installed
+----------------------------------------
+
+Redis is not directly exposed outside cluster. If need to access it from outside use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "keystore-data.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/keystore-data/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/keystore-data/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keystore-data.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keystore-data.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keystore-data.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/keystore-data/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/keystore-data/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "keystore-data.fullname" . }}
+  labels:
+    app: {{ template "keystore-data.name" . }}
+    chart: {{ template "keystore-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "keystore-data.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "keystore-data.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 6379
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deploy/k8s/archived/helm/keystore-data/templates/service.yaml
+++ b/deploy/k8s/archived/helm/keystore-data/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.inf.redis.keystore.svc }}
+  labels:
+    app: {{ template "keystore-data.name" . }}
+    chart: {{ template "keystore-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "keystore-data.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/keystore-data/values.yaml
+++ b/deploy/k8s/archived/helm/keystore-data/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: redis
+  tag: 4.0.10
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 6379
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/k8s/archived/helm/locations-api/.helmignore
+++ b/deploy/k8s/archived/helm/locations-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/locations-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/locations-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: locations-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/locations-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/locations-api/templates/NOTES.txt
@@ -1,0 +1,9 @@
+eShop Locations API installed.
+------------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "locations-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80
+

--- a/deploy/k8s/archived/helm/locations-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/locations-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "locations-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "locations-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "locations-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/locations-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/locations-api/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/locations-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/locations-api/templates/configmap.yaml
@@ -1,0 +1,22 @@
+{{- $name := include "locations-api.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $mongo := include "mongo-name" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "locations-api.name" . }}
+    chart: {{ template "locations-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  internalurls__IdentityUrl: http://{{ .Values.app.svc.identity }}
+  urls__IdentityUrl: {{ $identity }}
+  locations__ConnectionString: mongodb://{{ $mongo }}
+  locations__Database: {{ .Values.inf.mongo.locations.database }}

--- a/deploy/k8s/archived/helm/locations-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/locations-api/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $name := include "locations-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "locations-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "locations-api.name" . }}
+    chart: {{ template "locations-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "locations-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "locations-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}     
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}            
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/locations-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/locations-api/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.locations }}
+  labels:
+    app: {{ template "locations-api.name" . }}
+    chart: {{ template "locations-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "locations-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/locations-api/values.yaml
+++ b/deploy/k8s/archived/helm/locations-api/values.yaml
@@ -1,0 +1,66 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /locations-api
+
+image:
+  repository: eshop/locations.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: UseLoadTest
+      key: all_EnableLoadTest
+    - name: IdentityUrl
+      key: internalurls__IdentityUrl
+    - name: IdentityUrlExternal
+      key: urls__IdentityUrl
+    - name: ConnectionString
+      key: locations__ConnectionString
+    - name: Database
+      key: locations__Database
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/marketing-api/.helmignore
+++ b/deploy/k8s/archived/helm/marketing-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/marketing-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/marketing-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: marketing-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/marketing-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/marketing-api/templates/NOTES.txt
@@ -1,0 +1,9 @@
+eShop Marketing API installed.
+------------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "marketing-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80
+

--- a/deploy/k8s/archived/helm/marketing-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/marketing-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "marketing-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "marketing-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "marketing-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/marketing-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/marketing-api/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/marketing-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/marketing-api/templates/configmap.yaml
@@ -1,0 +1,27 @@
+{{- $name := include "marketing-api.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $webshoppingapigw := include "url-of" (list .Values.app.ingress.entries.webshoppingapigw .) -}}
+{{- $mongo := include "mongo-name" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "marketing-api.name" . }}
+    chart: {{ template "marketing-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  internalurls__IdentityUrl: http://{{ .Values.app.svc.identity }}
+  urls__IdentityUrl: {{ $protocol }}://{{ $identity }}
+  marketing__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.marketing.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  marketing__MongoConnectionString: mongodb://{{ $mongo }}
+  marketing__MongoDatabase: {{ .Values.inf.mongo.marketing.database }} 
+  marketing__PicBaseUrl: {{ $protocol }}://{{ $webshoppingapigw }}/c/api/v1/catalog/items/[0]/pic/

--- a/deploy/k8s/archived/helm/marketing-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/marketing-api/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $name := include "marketing-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "marketing-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "marketing-api.name" . }}
+    chart: {{ template "marketing-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "marketing-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "marketing-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}            
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/marketing-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/marketing-api/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.marketing }}
+  labels:
+    app: {{ template "marketing-api.name" . }}
+    chart: {{ template "marketing-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "marketing-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/marketing-api/values.yaml
+++ b/deploy/k8s/archived/helm/marketing-api/values.yaml
@@ -1,0 +1,70 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /marketing-api
+
+image:
+  repository: eshop/marketing.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: UseLoadTest
+      key: all_EnableLoadTest
+    - name: IdentityUrl
+      key: internalurls__IdentityUrl
+    - name: IdentityUrlExternal
+      key: urls__IdentityUrl
+    - name: ConnectionString
+      key: marketing__ConnectionString
+    - name: MongoConnectionString
+      key: marketing__MongoConnectionString
+    - name: MongoDatabase
+      key: marketing__MongoDatabase
+    - name: PicBaseUrl
+      key: marketing__PicBaseUrl
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/mobileshoppingagg/.helmignore
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/mobileshoppingagg/Chart.yaml
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: mobileshoppingagg
+version: 0.1.0

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Mobile Marketing Aggregator is installed
+----------------------------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mobileshoppingagg.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mobileshoppingagg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mobileshoppingagg.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mobileshoppingagg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/configmap.yaml
@@ -1,0 +1,29 @@
+{{- $name := include "mobileshoppingagg.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "mobileshoppingagg.name" . }}
+    chart: {{ template "mobileshoppingagg.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  mobileshoppingagg__keystore: {{ .Values.inf.redis.keystore.constr }}
+  internalurls__basket: http://{{ .Values.app.svc.basket }}
+  internalurls__catalog: http://{{ .Values.app.svc.catalog }}
+  internalurls__identity: http://{{ .Values.app.svc.identity }}
+  internalurls__ordering: http://{{ .Values.app.svc.ordering }}
+  internalurls__basket__hc: http://{{ .Values.app.svc.basket }}/hc
+  internalurls__catalog__hc: http://{{ .Values.app.svc.catalog }}/hc
+  internalurls__identity__hc: http://{{ .Values.app.svc.identity }}/hc
+  internalurls__ordering__hc: http://{{ .Values.app.svc.ordering }}/hc
+  internalurls__marketing__hc: http://{{ .Values.app.svc.marketing }}/hc
+  internalurls__payment__hc: http://{{ .Values.app.svc.payment }}/hc
+  internalurls__location__hc: http://{{ .Values.app.svc.locations }}/hc
+  internalurls__grpcBasket: "http://{{ .Values.app.svc.basket }}:{{ .Values.service.grpcPort }}"
+  internalurls__grpcCatalog: "http://{{ .Values.app.svc.catalog }}:{{ .Values.service.grpcPort }}"
+  internalurls__grpcOrdering: "http://{{ .Values.app.svc.ordering }}:{{ .Values.service.grpcPort }}"

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $name := include "mobileshoppingagg.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "mobileshoppingagg.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "mobileshoppingagg.name" . }}
+    chart: {{ template "mobileshoppingagg.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "mobileshoppingagg.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "mobileshoppingagg.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}                
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/mobileshoppingagg/templates/service.yaml
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.mobileshoppingagg }}
+  labels:
+    app: {{ template "mobileshoppingagg.name" . }}
+    chart: {{ template "mobileshoppingagg.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "mobileshoppingagg.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/mobileshoppingagg/values.yaml
+++ b/deploy/k8s/archived/helm/mobileshoppingagg/values.yaml
@@ -1,0 +1,85 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /mobileshoppingagg
+
+image:
+  repository: eshop/mobileshoppingagg
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  grpcPort: 81
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: urls__basket
+      key: internalurls__basket
+    - name: urls__catalog
+      key: internalurls__catalog
+    - name: urls__orders
+      key: internalurls__ordering
+    - name: urls__identity
+      key: internalurls__identity
+    - name: CatalogUrlHC
+      key: internalurls__catalog__hc
+    - name: BasketUrlHC
+      key: internalurls__basket__hc
+    - name: IdentityUrlHC
+      key: internalurls__identity__hc
+    - name: OrderingUrlHC
+      key: internalurls__ordering__hc
+    - name: MarketingUrlHC
+      key: internalurls__marketing__hc
+    - name: PaymentUrlHC
+      key: internalurls__payment__hc
+    - name: LocationUrlHC
+      key: internalurls__location__hc
+    - name: urls__grpcBasket
+      key: internalurls__grpcBasket
+    - name: urls__grpcCatalog
+      key: internalurls__grpcCatalog
+    - name: urls__grpcOrdering
+      key: internalurls__grpcOrdering      
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: ASPNETCORE_URLS
+      value: http://0.0.0.0:80
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      value: 'True'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/nosql-data/.helmignore
+++ b/deploy/k8s/archived/helm/nosql-data/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/nosql-data/Chart.yaml
+++ b/deploy/k8s/archived/helm/nosql-data/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nosql-data
+version: 0.1.0

--- a/deploy/k8s/archived/helm/nosql-data/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/nosql-data/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop MongoDb Installed
+-----------------------
+
+MongoDb is not exposed outside the cluster. If need to access it from outside, use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "nosql-data.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/nosql-data/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/nosql-data/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nosql-data.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nosql-data.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nosql-data.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/nosql-data/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/nosql-data/templates/_names.tpl
@@ -1,0 +1,8 @@
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/nosql-data/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/nosql-data/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "nosql-data.fullname" . }}
+  labels:
+    app: {{ template "nosql-data.name" . }}
+    chart: {{ template "nosql-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "nosql-data.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "nosql-data.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 27017
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deploy/k8s/archived/helm/nosql-data/templates/service.yaml
+++ b/deploy/k8s/archived/helm/nosql-data/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "mongo-name" . }}
+  labels:
+    app: {{ template "nosql-data.name" . }}
+    chart: {{ template "nosql-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "nosql-data.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/nosql-data/values.yaml
+++ b/deploy/k8s/archived/helm/nosql-data/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: mongo
+  tag: 3.6.5-jessie
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 27017
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/k8s/archived/helm/ordering-api/.helmignore
+++ b/deploy/k8s/archived/helm/ordering-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/ordering-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/ordering-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: ordering-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/ordering-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/ordering-api/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Ordering API installed.
+-----------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ordering-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/ordering-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/ordering-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ordering-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ordering-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ordering-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/ordering-api/templates/_names.tpl
@@ -1,0 +1,51 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/ordering-api/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- $name := include "ordering-api.fullname" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "ordering-api.name" . }}
+    chart: {{ template "ordering-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  ordering__EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  urls__IdentityUrl: http://{{ .Values.app.svc.identity }}
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/archived/helm/ordering-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/ordering-api/templates/deployment.yaml
@@ -1,0 +1,99 @@
+{{- $name := include "ordering-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "ordering-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "ordering-api.name" . }}
+    chart: {{ template "ordering-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ordering-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ordering-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}                      
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: grpc
+              containerPort: 81
+              protocol: TCP              
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/ordering-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/ordering-api/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.ordering }}
+  labels:
+    app: {{ template "ordering-api.name" . }}
+    chart: {{ template "ordering-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app: {{ template "ordering-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/ordering-api/values.yaml
+++ b/deploy/k8s/archived/helm/ordering-api/values.yaml
@@ -1,0 +1,69 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /ordering-api
+
+image:
+  repository: eshop/ordering.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  grpcPort: 81
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ConnectionString
+      key: ordering__ConnectionString
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: UseLoadTest
+      key: ordering__EnableLoadTest
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: PORT
+      value: "80"
+    - name: GRPC_PORT
+      value: "81"      
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/.helmignore
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/Chart.yaml
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: ordering-backgroundtasks
+version: 0.1.0

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/NOTES.txt
@@ -1,0 +1,3 @@
+eShop Ordering Background Tasks installed.
+------------------------------------------
+

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ordering-backgroundtasks.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ordering-backgroundtasks.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ordering-backgroundtasks.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/_names.tpl
@@ -1,0 +1,51 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- $name := include "ordering-backgroundtasks.fullname" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+{{- $cfgname :=  printf "cfg-%s" $name | trunc 63  }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ $cfgname }}"
+  labels:
+    app: {{ template "ordering-backgroundtasks.name" . }}
+    chart: {{ template "ordering-backgroundtasks.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  ordering__EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  graceperiodmanager__CheckUpdateTime: "{{ .Values.cfg.checkUpdateTime }}"
+  graceperiodmanager__GracePeriodTime: "{{ .Values.cfg.gracePeriodTime }}"

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/deployment.yaml
@@ -1,0 +1,92 @@
+{{- $name := include "ordering-backgroundtasks.fullname" . -}}
+{{- $cfgname :=  printf "cfg-%s" $name | trunc 63  }}
+
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "ordering-backgroundtasks.fullname" . }}
+  labels:
+    app: {{ template "ordering-backgroundtasks.name" . }}
+    chart: {{ template "ordering-backgroundtasks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ordering-backgroundtasks.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ordering-backgroundtasks.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}            
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/service.yaml
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.orderingbackgroundtasks }}
+  labels:
+    app: {{ template "ordering-backgroundtasks.name" . }}
+    chart: {{ template "ordering-backgroundtasks.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "ordering-backgroundtasks.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/ordering-backgroundtasks/values.yaml
+++ b/deploy/k8s/archived/helm/ordering-backgroundtasks/values.yaml
@@ -1,0 +1,70 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /ordering-backgroundtasks
+
+image:
+  repository: eshop/ordering.backgroundtasks
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+cfg:
+  checkUpdateTime: "15000"
+  gracePeriodTime: "1"
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ConnectionString
+      key: ordering__ConnectionString
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: UseLoadTest
+      key: ordering__EnableLoadTest      
+    - name: CheckUpdateTime
+      key: graceperiodmanager__CheckUpdateTime
+    - name: GracePeriodTime
+      key: graceperiodmanager__GracePeriodTime
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/ordering-signalrhub/.helmignore
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/ordering-signalrhub/Chart.yaml
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: ordering-signalrhub
+version: 0.1.0

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Ordering SignalR Hub installed
+------------------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ordering-signalrhub.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ordering-signalrhub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ordering-signalrhub.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ordering-signalrhub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/_names.tpl
@@ -1,0 +1,51 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- $name := include "ordering-signalrhub.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "ordering-signalrhub.name" . }}
+    chart: {{ template "ordering-signalrhub.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  signalr__StoreConnectionString: {{ .Values.inf.redis.keystore.constr }}
+  urls__IdentityUrl: http://{{ $identity }}

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/deployment.yaml
@@ -1,0 +1,70 @@
+{{- $name := include "ordering-signalrhub.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "ordering-signalrhub.fullname" . }}
+  labels:
+    app: {{ template "ordering-signalrhub.name" . }}
+    chart: {{ template "ordering-signalrhub.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ordering-signalrhub.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ordering-signalrhub.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/ordering-signalrhub/templates/service.yaml
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.orderingsignalrhub }}
+  labels:
+    app: {{ template "ordering-signalrhub.name" . }}
+    chart: {{ template "ordering-signalrhub.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "ordering-signalrhub.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/ordering-signalrhub/values.yaml
+++ b/deploy/k8s/archived/helm/ordering-signalrhub/values.yaml
@@ -1,0 +1,57 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /ordering-signalrhub
+
+image:
+  repository: eshop/ordering.signalrhub
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+cfg:
+  checkUpdateTime: "15000"
+  gracePeriodTime: "1"
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+    - name: SignalrStoreConnectionString
+      key: signalr__StoreConnectionString
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      values: 'True'
+

--- a/deploy/k8s/archived/helm/payment-api/.helmignore
+++ b/deploy/k8s/archived/helm/payment-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/payment-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/payment-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: payment-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/payment-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/payment-api/templates/NOTES.txt
@@ -1,0 +1,9 @@
+eShop Payment API installed.
+----------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "payment-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80
+

--- a/deploy/k8s/archived/helm/payment-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/payment-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "payment-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "payment-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "payment-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/payment-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/payment-api/templates/_names.tpl
@@ -1,0 +1,51 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/payment-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/payment-api/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- $name := include "payment-api.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "payment-api.name" . }}
+    chart: {{ template "payment-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/archived/helm/payment-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/payment-api/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $name := include "payment-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "payment-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "payment-api.name" . }}
+    chart: {{ template "payment-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "payment-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "payment-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}                
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/payment-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/payment-api/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.payment }}
+  labels:
+    app: {{ template "payment-api.name" . }}
+    chart: {{ template "payment-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "payment-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/payment-api/values.yaml
+++ b/deploy/k8s/archived/helm/payment-api/values.yaml
@@ -1,0 +1,56 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /payment-api
+
+image:
+  repository: eshop/payment.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60
+    port: 80

--- a/deploy/k8s/archived/helm/rabbitmq/.helmignore
+++ b/deploy/k8s/archived/helm/rabbitmq/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/rabbitmq/Chart.yaml
+++ b/deploy/k8s/archived/helm/rabbitmq/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: rabbitmq
+version: 0.1.0

--- a/deploy/k8s/archived/helm/rabbitmq/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/rabbitmq/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop rabbitmq installed
+-------------------------
+
+rabbitmq is not directly exposed outside cluster. If need to access it from outside use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rabbitmq.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/rabbitmq/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/rabbitmq/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rabbitmq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rabbitmq.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rabbitmq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/rabbitmq/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/rabbitmq/templates/_names.tpl
@@ -1,0 +1,8 @@
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "rabbitmq" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/rabbitmq/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/rabbitmq/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "rabbitmq.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5672
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deploy/k8s/archived/helm/rabbitmq/templates/service.yaml
+++ b/deploy/k8s/archived/helm/rabbitmq/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.inf.eventbus.svc }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "rabbitmq.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/rabbitmq/values.yaml
+++ b/deploy/k8s/archived/helm/rabbitmq/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: rabbitmq
+  tag: 3-management
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 5672
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/k8s/archived/helm/sql-data/.helmignore
+++ b/deploy/k8s/archived/helm/sql-data/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/sql-data/Chart.yaml
+++ b/deploy/k8s/archived/helm/sql-data/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: sql-data
+version: 0.1.0

--- a/deploy/k8s/archived/helm/sql-data/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/sql-data/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop SQL Server Installed
+--------------------------
+
+SQL server is not exposed outside the cluster. If need to access it from outside, use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "sql-data.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/sql-data/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/sql-data/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sql-data.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sql-data.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sql-data.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/sql-data/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/sql-data/templates/_names.tpl
@@ -1,0 +1,8 @@
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/sql-data/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/sql-data/templates/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "sql-data.fullname" . }}
+  labels:
+    app: {{ template "sql-data.name" . }}
+    chart: {{ template "sql-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "sql-data.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "sql-data.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: ACCEPT_EULA
+            value: "Y"
+          - name: MSSQL_PID
+            value: {{ .Values.inf.sql.common.pid }}
+          - name: MSSQL_SA_PASSWORD
+            value: {{ .Values.inf.sql.common.pwd }}
+          ports:
+            - name: http
+              containerPort: 1433
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deploy/k8s/archived/helm/sql-data/templates/service.yaml
+++ b/deploy/k8s/archived/helm/sql-data/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sql-name" . }}
+  labels:
+    app: {{ template "sql-data.name" . }}
+    chart: {{ template "sql-data.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "sql-data.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/sql-data/values.yaml
+++ b/deploy/k8s/archived/helm/sql-data/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: microsoft/mssql-server-linux
+  tag: 2017-CU7
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 1433
+
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/k8s/archived/helm/tls-support/.helmignore
+++ b/deploy/k8s/archived/helm/tls-support/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/tls-support/Chart.yaml
+++ b/deploy/k8s/archived/helm/tls-support/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: tt-ssl
+version: 0.1.0

--- a/deploy/k8s/archived/helm/tls-support/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/tls-support/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tt-tls.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tt-tls.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tt-tls.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/tls-support/templates/issuer.yaml
+++ b/deploy/k8s/archived/helm/tls-support/templates/issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ .Values.issuerName }}
+  namespace: default
+  environment: {{ .Values.environment }}
+  app: {{ .Values.applicationName }}
+spec:
+  acme:
+    server: {{ .Values.server }}
+    email: not@used.com
+    privateKeySecretRef:
+      name: {{ .Values.issuerSecretName }}
+    solvers:
+    - http01:
+        ingress:
+          class: {{ .Values.ingressClass }}      

--- a/deploy/k8s/archived/helm/tls-support/values-prod.yaml
+++ b/deploy/k8s/archived/helm/tls-support/values-prod.yaml
@@ -1,0 +1,8 @@
+applicationName: eshop
+issuerName: letsencrypt-prod
+certName: eshop-cert-prod
+environment: prod
+server: https://acme-v02.api.letsencrypt.org/directory
+certSecretName: eshop-letsencrypt-prod
+issuerSecretName: letsencrypt-prod
+ingressClass: addon-http-application-routing

--- a/deploy/k8s/archived/helm/tls-support/values-staging.yaml
+++ b/deploy/k8s/archived/helm/tls-support/values-staging.yaml
@@ -1,0 +1,8 @@
+applicationName: eshop
+issuerName: letsencrypt-staging
+certName: eshop-cert-staging
+environment: staging
+server: https://acme-staging-v02.api.letsencrypt.org/directory
+certSecretName: eshop-letsencrypt-staging
+issuerSecretName: letsencrypt-staging
+ingressClass: addon-http-application-routing

--- a/deploy/k8s/archived/helm/webhooks-api/.helmignore
+++ b/deploy/k8s/archived/helm/webhooks-api/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webhooks-api/Chart.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webhooks-api
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webhooks-api/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Ordering API installed.
+-----------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "webhooks-api.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/webhooks-api/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webhooks-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webhooks-api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webhooks-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webhooks-api/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webhooks-api/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- $name := include "webhooks-api.fullname" . -}}
+{{- $sqlsrv := include "sql-name" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webhooks-api.name" . }}
+    chart: {{ template "webhooks-api.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  webhooks__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.webhooks.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  urls__IdentityUrl: http://{{ $identity }}
+  urls__IdentityUrlExternal: {{ $protocol }}://{{ $identity }}
+  all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/archived/helm/webhooks-api/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- $name := include "webhooks-api.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webhooks-api.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "webhooks-api.name" . }}
+    chart: {{ template "webhooks-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webhooks-api.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webhooks-api.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webhooks-api/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.webhooks }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "webhooks-api.fullname" . }}
+  labels:
+    app: {{ template "webhooks-api.name" . }}
+    chart: {{ template "webhooks-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/webhooks-api/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.webhooks }}
+  labels:
+    app: {{ template "webhooks-api.name" . }}
+    chart: {{ template "webhooks-api.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webhooks-api.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webhooks-api/values.yaml
+++ b/deploy/k8s/archived/helm/webhooks-api/values.yaml
@@ -1,0 +1,53 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webhooks-api
+
+image:
+  repository: eshop/webhooks.api
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ConnectionString
+      key: webhooks__ConnectionString
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: EventBusConnection
+      key: all__EventBusConnection
+    - name: AzureServiceBusEnabled
+      key: all__UseAzureServiceBus
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+    - name: IdentityUrlExternal
+      key: urls__IdentityUrlExternal
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+

--- a/deploy/k8s/archived/helm/webhooks-web/.helmignore
+++ b/deploy/k8s/archived/helm/webhooks-web/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webhooks-web/Chart.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webhooks-web
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webhooks-web/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Ordering API installed.
+-----------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "webhooks-web.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/webhooks-web/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webhooks-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webhooks-web.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webhooks-web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webhooks-web/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webhooks-web/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{- $name := include "webhooks-web.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $webhooksweb := include "url-of" (list .Values.app.ingress.entries.webhooksweb .) -}}
+{{- $webhooks := include "url-of" (list .Values.app.ingress.entries.webhooks .) -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webhooks-web.name" . }}
+    chart: {{ template "webhooks-web.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  urls__webhooks: {{ $protocol }}://{{ $webhooks }}
+  identity_e: {{ $protocol }}://{{ $identity }}
+  webhooksweb_e: {{ $protocol }}://{{ $webhooksweb }}
+  urls_webhooksweb: http://{{ .Values.app.svc.webhooksweb }}

--- a/deploy/k8s/archived/helm/webhooks-web/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- $name := include "webhooks-web.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webhooks-web.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "webhooks-web.name" . }}
+    chart: {{ template "webhooks-web.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webhooks-web.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webhooks-web.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webhooks-web/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "webhooks-web.fullname" . }}
+  labels:
+    app: {{ template "webhooks-web.name" . }}
+    chart: {{ template "webhooks-web.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $.Values.app.svc.webhooksweb }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/webhooks-web/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.webhooksweb }}
+  labels:
+    app: {{ template "webhooks-web.name" . }}
+    chart: {{ template "webhooks-web.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webhooks-web.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webhooks-web/values.yaml
+++ b/deploy/k8s/archived/helm/webhooks-web/values.yaml
@@ -1,0 +1,52 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webhooks-web
+
+image:
+  repository: eshop/webhooks.client
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+  hosts:
+    - chart-example.local
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: WebhooksUrl
+      key: urls__webhooks
+    - name: IdentityUrl
+      key: identity_e
+    - name: CallbackUrl
+      key: webhooksweb_e
+    - name: SelfUrl
+      key: webhooksweb_e
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Production
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: Token
+      value: "WebHooks-Demo-Web"       # Can use whatever you want
+
+

--- a/deploy/k8s/archived/helm/webmvc/.helmignore
+++ b/deploy/k8s/archived/helm/webmvc/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webmvc/Chart.yaml
+++ b/deploy/k8s/archived/helm/webmvc/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webmvc
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webmvc/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webmvc/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop WebMVC installed.
+-----------------------

--- a/deploy/k8s/archived/helm/webmvc/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webmvc/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webmvc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webmvc.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webmvc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webmvc/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webmvc/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webmvc/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webmvc/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{- $name := include "webmvc.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $webshoppingapigw := include "url-of" (list .Values.app.ingress.entries.webshoppingapigw .) -}}
+{{- $mvc := include "url-of" (list .Values.app.ingress.entries.mvc .) -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webmvc.name" . }}
+    chart: {{ template "webmvc.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  webmvc__keystore: {{ .Values.inf.redis.keystore.constr }}
+  internalurls__apigwws: http://{{ .Values.app.svc.webshoppingapigw }}
+  internalurls__apigwwm: http://{{ .Values.app.svc.webmarketingapigw }}
+  internalurls__identity__hc: http://{{ .Values.app.svc.identity }}/hc
+  urls__apigwws: {{ $protocol }}://{{ $webshoppingapigw }}
+  urls__mvc: {{ $protocol }}://{{ $mvc }}
+  urls__IdentityUrl: {{ $protocol }}://{{ $identity }}

--- a/deploy/k8s/archived/helm/webmvc/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webmvc/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- $name := include "webmvc.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webmvc.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "webmvc.name" . }}
+    chart: {{ template "webmvc.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webmvc.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webmvc.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webmvc/templates/ingress-dockerk8s.yaml
+++ b/deploy/k8s/archived/helm/webmvc/templates/ingress-dockerk8s.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- if .Values.inf.k8s.local -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.mvc }}
+{{- $name := include "webmvc.fullname" . -}} 
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $name }}-local
+  labels:
+    app: {{ template "webmvc.name" . }}
+    chart: {{ template "webmvc.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}    
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {{ $serviceName }}
+          servicePort: http
+        path: {{ $ingressPath }}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webmvc/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/webmvc/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+{{- $serviceName := .Values.app.svc.mvc -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "webmvc.fullname" . }}
+  labels:
+    app: {{ template "webmvc.name" . }}
+    chart: {{ template "webmvc.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/webmvc/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webmvc/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.mvc }}
+  labels:
+    app: {{ template "webmvc.name" . }}
+    chart: {{ template "webmvc.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webmvc.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webmvc/values.yaml
+++ b/deploy/k8s/archived/helm/webmvc/values.yaml
@@ -1,0 +1,61 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webmvc
+
+image:
+  repository: eshop/webmvc
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: UseLoadTest
+      key: all_EnableLoadTest
+    - name: DPConnectionString
+      key: webmvc__keystore
+    - name: PurchaseUrl
+      key: internalurls__apigwws
+    - name: ExternalPurchaseUrl
+      key: urls__apigwws
+    - name: CallBackUrl
+      key: urls__mvc
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+    - name: MarketingUrl
+      key: internalurls__apigwwm
+    - name: IdentityUrlHC
+      key: internalurls__identity__hc      
+    - name: SignalrHubUrl
+      key: urls__apigwws
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      value: 'True'
+

--- a/deploy/k8s/archived/helm/webshoppingagg/.helmignore
+++ b/deploy/k8s/archived/helm/webshoppingagg/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webshoppingagg/Chart.yaml
+++ b/deploy/k8s/archived/helm/webshoppingagg/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webshoppingagg
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/NOTES.txt
@@ -1,0 +1,8 @@
+eShop Web Shopping Aggregator installed.
+----------------------------------------
+
+This API is not directly exposed outside cluster. If need to access it use:
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "webshoppingagg.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+echo "Visit http://127.0.0.1:8080 to use your application"
+kubectl port-forward $POD_NAME 8080:80

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webshoppingagg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webshoppingagg.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webshoppingagg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/_names.tpl
@@ -1,0 +1,52 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/configmap.yaml
@@ -1,0 +1,29 @@
+{{- $name := include "webshoppingagg.fullname" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webshoppingagg.name" . }}
+    chart: {{ template "webshoppingagg.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  webshoppingagg__keystore: {{ .Values.inf.redis.keystore.constr }}
+  internalurls__basket: http://{{ .Values.app.svc.basket }}
+  internalurls__catalog: http://{{ .Values.app.svc.catalog }}
+  internalurls__identity: http://{{ .Values.app.svc.identity }}
+  internalurls__ordering: http://{{ .Values.app.svc.ordering }}
+  internalurls__basket__hc: http://{{ .Values.app.svc.basket }}/hc
+  internalurls__catalog__hc: http://{{ .Values.app.svc.catalog }}/hc
+  internalurls__identity__hc: http://{{ .Values.app.svc.identity }}/hc
+  internalurls__ordering__hc: http://{{ .Values.app.svc.ordering }}/hc
+  internalurls__marketing__hc: http://{{ .Values.app.svc.marketing }}/hc
+  internalurls__payment__hc: http://{{ .Values.app.svc.payment }}/hc
+  internalurls__location__hc: http://{{ .Values.app.svc.locations }}/hc
+  internalurls__grpcBasket: "http://{{ .Values.app.svc.basket }}:{{ .Values.service.grpcPort }}"
+  internalurls__grpcCatalog: "http://{{ .Values.app.svc.catalog }}:{{ .Values.service.grpcPort }}"
+  internalurls__grpcOrdering: "http://{{ .Values.app.svc.ordering }}:{{ .Values.service.grpcPort }}"

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/deployment.yaml
@@ -1,0 +1,95 @@
+{{- $name := include "webshoppingagg.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webshoppingagg.fullname" . }}
+  labels:
+    app: {{ template "webshoppingagg.name" . }}
+    chart: {{ template "webshoppingagg.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}    
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webshoppingagg.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webshoppingagg.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{ if .Values.probes -}}
+          {{- if .Values.probes.liveness -}}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.probes.liveness.port }}
+              path: {{ .Values.probes.liveness.path }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.probes -}}
+          {{- if .Values.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.probes.readiness.port }}
+              path: {{ .Values.probes.readiness.path }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end -}}
+          {{- end }}              
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webshoppingagg/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webshoppingagg/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.webshoppingagg }}
+  labels:
+    app: {{ template "webshoppingagg.name" . }}
+    chart: {{ template "webshoppingagg.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webshoppingagg.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webshoppingagg/values.yaml
+++ b/deploy/k8s/archived/helm/webshoppingagg/values.yaml
@@ -1,0 +1,87 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webshoppingagg
+
+image:
+  repository: eshop/webshoppingagg
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  grpcPort: 81
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: urls__basket
+      key: internalurls__basket
+    - name: urls__catalog
+      key: internalurls__catalog
+    - name: urls__orders
+      key: internalurls__ordering
+    - name: urls__identity
+      key: internalurls__identity
+    - name: CatalogUrlHC
+      key: internalurls__catalog__hc
+    - name: BasketUrlHC
+      key: internalurls__basket__hc
+    - name: IdentityUrlHC
+      key: internalurls__identity__hc
+    - name: OrderingUrlHC
+      key: internalurls__ordering__hc
+    - name: MarketingUrlHC
+      key: internalurls__marketing__hc
+    - name: PaymentUrlHC
+      key: internalurls__payment__hc
+    - name: LocationUrlHC
+      key: internalurls__location__hc
+    - name: urls__grpcBasket
+      key: internalurls__grpcBasket
+    - name: urls__grpcCatalog
+      key: internalurls__grpcCatalog
+    - name: urls__grpcOrdering
+      key: internalurls__grpcOrdering
+
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: ASPNETCORE_URLS
+      value: http://0.0.0.0:80
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      value: 'True'
+probes:
+  liveness:
+    path: /liveness
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    port: 80
+  readiness:
+    path: /hc
+    timeoutSeconds: 5
+    initialDelaySeconds: 90
+    periodSeconds: 60      
+    port: 80
+

--- a/deploy/k8s/archived/helm/webspa/.helmignore
+++ b/deploy/k8s/archived/helm/webspa/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webspa/Chart.yaml
+++ b/deploy/k8s/archived/helm/webspa/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webspa
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webspa/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webspa/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop WebSPA installed
+----------------------

--- a/deploy/k8s/archived/helm/webspa/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webspa/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webspa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webspa.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webspa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webspa/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webspa/templates/_names.tpl
@@ -1,0 +1,60 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "protocol" -}}
+{{- if .Values.inf.tls.enabled -}}
+{{- printf "%s" "https" -}}
+{{- else -}}
+{{- printf "%s" "http" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webspa/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webspa/templates/configmap.yaml
@@ -1,0 +1,27 @@
+{{- $name := include "webspa.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $webshoppingapigw := include "url-of" (list .Values.app.ingress.entries.webshoppingapigw .) -}}
+{{- $webmarketingapigw := include "url-of" (list .Values.app.ingress.entries.webmarketingapigw .) -}}
+{{- $spa := include "url-of" (list .Values.app.ingress.entries.spa .) -}}
+{{- $mongo := include "mongo-name" . -}}
+{{- $protocol := include "protocol" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webspa.name" . }}
+    chart: {{ template "webspa.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  webspa__keystore: {{ .Values.inf.redis.keystore.constr }}
+  internalurls__apigwws: http://{{ .Values.app.svc.webshoppingapigw }}
+  internalurls__identity__hc: http://{{ .Values.app.svc.identity }}/hc
+  urls__apigwws: {{ $protocol }}://{{ $webshoppingapigw }}
+  urls__spa: {{ $protocol }}://{{ $spa }}
+  urls__IdentityUrl: {{ $protocol }}://{{ $identity }}
+  urls__apigwwm: {{ $protocol }}://{{ $webmarketingapigw }}

--- a/deploy/k8s/archived/helm/webspa/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webspa/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- $name := include "webspa.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webspa.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "webspa.name" . }}
+    chart: {{ template "webspa.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webspa.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webspa.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}          
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webspa/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/webspa/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := include "pathBase" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "webspa.fullname" . }}
+  labels:
+    app: {{ template "webspa.name" . }}
+    chart: {{ template "webspa.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $.Values.app.svc.spa }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/webspa/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webspa/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.spa }}
+  labels:
+    app: {{ template "webspa.name" . }}
+    chart: {{ template "webspa.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webspa.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webspa/values.yaml
+++ b/deploy/k8s/archived/helm/webspa/values.yaml
@@ -1,0 +1,61 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /
+
+image:
+  repository: eshop/webspa
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: UseLoadTest
+      key: all_EnableLoadTest
+    - name: DPConnectionString
+      key: webspa__keystore
+    - name: PurchaseUrl
+      key: urls__apigwws
+    - name: CallBackUrl
+      key: urls__spa
+    - name: IdentityUrl
+      key: urls__IdentityUrl
+    - name: MarketingUrl
+      key: urls__apigwwm
+    - name: IdentityUrlHC
+      key: internalurls__identity__hc      
+    - name: SignalrHubUrl
+      key: urls__apigwws
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: ASPNETCORE_URLS
+      value: http://0.0.0.0:80
+    - name: OrchestratorType
+      value: 'K8S'
+    - name: IsClusterEnv
+      value: 'True'
+

--- a/deploy/k8s/archived/helm/webstatus/.helmignore
+++ b/deploy/k8s/archived/helm/webstatus/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/k8s/archived/helm/webstatus/Chart.yaml
+++ b/deploy/k8s/archived/helm/webstatus/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: webstatus
+version: 0.1.0

--- a/deploy/k8s/archived/helm/webstatus/templates/NOTES.txt
+++ b/deploy/k8s/archived/helm/webstatus/templates/NOTES.txt
@@ -1,0 +1,2 @@
+eShop WebStatus installed.
+--------------------------

--- a/deploy/k8s/archived/helm/webstatus/templates/_helpers.tpl
+++ b/deploy/k8s/archived/helm/webstatus/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webstatus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webstatus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "webstatus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webstatus/templates/_names.tpl
+++ b/deploy/k8s/archived/helm/webstatus/templates/_names.tpl
@@ -1,0 +1,50 @@
+{{- define "suffix-name" -}}
+{{- if .Values.app.name -}}
+{{- .Values.app.name -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sql-name" -}}
+{{- if .Values.inf.sql.host -}}
+{{- .Values.inf.sql.host -}}
+{{- else -}}
+{{- printf "%s" "sql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mongo-name" -}}
+{{- if .Values.inf.mongo.host -}}
+{{- .Values.inf.mongo.host -}}
+{{- else -}}
+{{- printf "%s" "nosql-data" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "url-of" -}}
+{{- $name := first .}}
+{{- $ctx := last .}}
+{{- if eq $name "" -}}
+{{- $ctx.Values.inf.k8s.dns -}}
+{{- else -}}
+{{- printf "%s/%s" $ctx.Values.inf.k8s.dns $name -}}                {{/*Value is just <dns>/<name> */}}
+{{- end -}}
+{{- end -}}
+
+{{- define "pathBase" -}}
+{{- if .Values.inf.k8s.suffix -}}
+{{- $suffix := include "suffix-name" . -}}
+{{- printf "%s-%s"  .Values.pathBase $suffix -}}
+{{- else -}}
+{{- .Values.pathBase -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fqdn-image" -}}
+{{- if .Values.inf.registry -}}
+{{- printf "%s/%s" .Values.inf.registry.server .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/k8s/archived/helm/webstatus/templates/configmap.yaml
+++ b/deploy/k8s/archived/helm/webstatus/templates/configmap.yaml
@@ -1,0 +1,54 @@
+{{- $name := include "webstatus.fullname" . -}}
+{{- $identity := include "url-of" (list .Values.app.ingress.entries.identity .) -}}
+{{- $webshoppingapigw := include "url-of" (list .Values.app.ingress.entries.webshoppingapigw .) -}}
+{{- $mvc := include "url-of" (list .Values.app.ingress.entries.mvc .) -}}
+{{- $mongo := include "mongo-name" . -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cfg-{{ $name }}"
+  labels:
+    app: {{ template "webstatus.name" . }}
+    chart: {{ template "webstatus.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
+  all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"
+  all_EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
+  webstatus__keystore: {{ .Values.inf.redis.keystore.constr }}
+  name__mvc__hc: WebMVC HTTP Check
+  internalurls__mvc__hc: http://{{ .Values.app.svc.mvc }}/hc
+  name__spa__hc: WebSPA HTTP Check
+  internalurls__spa__hc: http://{{ .Values.app.svc.spa }}/hc
+  name__apigwws__hc: Web Shopping API GW HTTP Check
+  internalurls__apigwws__hc: http://{{ .Values.app.svc.webshoppingapigw }}:8001/ready
+  name__apigwwm__hc: Web Marketing API GW HTTP Check
+  internalurls__apigwwm__hc: http://{{ .Values.app.svc.webmarketingapigw }}:8001/ready
+  name__apigwms__hc: Mobile Shopping API GW HTTP Check
+  internalurls__apigwms__hc: http://{{ .Values.app.svc.mobileshoppingapigw }}:8001/ready
+  name__apigwmm__hc: Mobile Marketing API GW HTTP Check
+  internalurls__apigwmm__hc: http://{{ .Values.app.svc.mobilemarketingapigw }}:8001/ready
+  name__apigwwsagg__hc: Web Shopping Aggregator GW HTTP Check
+  internalurls__apigwwsagg__hc: http://{{ .Values.app.svc.webshoppingagg }}/hc
+  name__apigwmsagg__hc: Mobile Shopping Aggregator HTTP Check
+  internalurls__apigwmsagg__hc: http://{{ .Values.app.svc.mobileshoppingagg }}/hc
+  name__ordering__hc: Ordering HTTP Check
+  internalurls__ordering__hc: http://{{ .Values.app.svc.ordering }}/hc
+  name__orderingbackground__hc: Ordering HTTP Background Check
+  internalurls__orderingbackground__hc: http://{{ .Values.app.svc.orderingbackgroundtasks }}/hc
+  name__basket__hc: Basket HTTP Check
+  internalurls__basket__hc: http://{{ .Values.app.svc.basket }}/hc
+  name__catalog__hc: Catalog HTTP Check
+  internalurls__catalog__hc: http://{{ .Values.app.svc.catalog }}/hc
+  name__identity__hc: Identity HTTP Check
+  internalurls__identity__hc: http://{{ .Values.app.svc.identity }}/hc
+  name__marketing__hc: Marketing HTTP Check
+  internalurls__marketing__hc: http://{{ .Values.app.svc.marketing }}/hc
+  name__locations__hc: Locations HTTP Check
+  internalurls__locations__hc: http://{{ .Values.app.svc.locations }}/hc
+  name__payment__hc: Payment HTTP Check
+  internalurls__payment__hc: http://{{ .Values.app.svc.payment }}/hc
+  name__signalrhub__hc: Ordering SignalR Hub HTTP Check
+  internalurls__signalrhub__hc: http://{{ .Values.app.svc.orderingsignalrhub }}/hc

--- a/deploy/k8s/archived/helm/webstatus/templates/deployment.yaml
+++ b/deploy/k8s/archived/helm/webstatus/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- $name := include "webstatus.fullname" . -}}
+{{- $cfgname := printf "%s-%s" "cfg" $name -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "webstatus.fullname" . }}
+  labels:
+    ufo: {{ $cfgname}}
+    app: {{ template "webstatus.name" . }}
+    chart: {{ template "webstatus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webstatus.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "webstatus.name" . }}
+        release: {{ .Release.Name }}
+      {{ if .Values.inf.mesh.enabled -}}
+      annotations:
+        linkerd.io/inject: enabled
+      {{- end }}             
+    spec:
+      {{ if .Values.inf.registry -}}
+      imagePullSecrets:
+      - name: {{ .Values.inf.registry.secretName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ template "fqdn-image" . }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH_BASE
+              value: {{ include "pathBase" . }}
+            - name: k8sname
+              value: {{ .Values.clusterName }}
+          {{- if .Values.env.values -}}
+          {{- range .Values.env.values }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end -}}
+          {{- end -}}
+          {{- if .Values.env.configmap -}}
+          {{- range .Values.env.configmap }}
+            - name: {{ .name }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $cfgname }}
+                  key: {{ .key }}
+          {{- end -}}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/deploy/k8s/archived/helm/webstatus/templates/ingress.yaml
+++ b/deploy/k8s/archived/helm/webstatus/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "webstatus.fullname" . -}}
+{{- $ingressPath := include "pathBase" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "webstatus.fullname" . }}
+  labels:
+    app: {{ template "webstatus.name" . }}
+    chart: {{ template "webstatus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}
+    cert-manager.io/issuer: {{ .Values.inf.tls.issuer }} 
+{{- end }}
+{{- if .Values.inf.mesh.enabled }} 
+{{- with .Values.ingress.mesh.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $.Values.app.svc.status }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deploy/k8s/archived/helm/webstatus/templates/service.yaml
+++ b/deploy/k8s/archived/helm/webstatus/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.status }}
+  labels:
+    app: {{ template "webstatus.name" . }}
+    chart: {{ template "webstatus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "webstatus.name" . }}
+    release: {{ .Release.Name }}

--- a/deploy/k8s/archived/helm/webstatus/values.yaml
+++ b/deploy/k8s/archived/helm/webstatus/values.yaml
@@ -1,0 +1,95 @@
+replicaCount: 1
+clusterName: eshop-aks
+pathBase: /webstatus
+
+image:
+  repository: eshop/webstatus
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {
+
+  }
+  tls: []
+
+resources: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# env defines the environment variables that will be declared in the pod
+env:
+  urls:
+  # configmap declares variables which value is taken from the config map defined in template configmap.yaml (name is name of var and key the key in configmap).
+  configmap:
+    - name: ApplicationInsights__InstrumentationKey
+      key: all__InstrumentationKey
+    - name: HealthChecks-UI__HealthChecks__0__Name
+      key: name__mvc__hc
+    - name: HealthChecks-UI__HealthChecks__0__Uri
+      key: internalurls__mvc__hc
+    - name: HealthChecks-UI__HealthChecks__1__Name
+      key: name__spa__hc
+    - name: HealthChecks-UI__HealthChecks__1__Uri
+      key: internalurls__spa__hc
+    - name: HealthChecks-UI__HealthChecks__2__Name
+      key: name__apigwwsagg__hc
+    - name: HealthChecks-UI__HealthChecks__2__Uri
+      key: internalurls__apigwwsagg__hc
+    - name: HealthChecks-UI__HealthChecks__3__Name
+      key: name__apigwmsagg__hc
+    - name: HealthChecks-UI__HealthChecks__3__Uri
+      key: internalurls__apigwmsagg__hc
+    - name: HealthChecks-UI__HealthChecks__4__Name
+      key: name__ordering__hc
+    - name: HealthChecks-UI__HealthChecks__4__Uri
+      key: internalurls__ordering__hc
+    - name: HealthChecks-UI__HealthChecks__5__Name
+      key: name__basket__hc
+    - name: HealthChecks-UI__HealthChecks__5__Uri
+      key: internalurls__basket__hc
+    - name: HealthChecks-UI__HealthChecks__6__Name
+      key: name__catalog__hc
+    - name: HealthChecks-UI__HealthChecks__6__Uri
+      key: internalurls__catalog__hc
+    - name: HealthChecks-UI__HealthChecks__7__Name
+      key: name__identity__hc
+    - name: HealthChecks-UI__HealthChecks__7__Uri
+      key: internalurls__identity__hc
+    - name: HealthChecks-UI__HealthChecks__8__Name
+      key: name__marketing__hc
+    - name: HealthChecks-UI__HealthChecks__8__Uri
+      key: internalurls__marketing__hc
+    - name: HealthChecks-UI__HealthChecks__9__Name
+      key: name__locations__hc
+    - name: HealthChecks-UI__HealthChecks__9__Uri
+      key: internalurls__locations__hc
+    - name: HealthChecks-UI__HealthChecks__10__Name
+      key: name__payment__hc
+    - name: HealthChecks-UI__HealthChecks__10__Uri
+      key: internalurls__payment__hc
+    - name: HealthChecks-UI__HealthChecks__11__Name
+      key: name__signalrhub__hc
+    - name: HealthChecks-UI__HealthChecks__11__Uri
+      key: internalurls__signalrhub__hc
+    - name: HealthChecks-UI__HealthChecks__12__Name
+      key: name__orderingbackground__hc
+    - name: HealthChecks-UI__HealthChecks__12__Uri
+      key: internalurls__orderingbackground__hc
+
+      # values define environment variables with a fixed value (no configmap involved) (name is name of var, and value is its value)
+  values:
+    - name: ASPNETCORE_ENVIRONMENT
+      value: Development
+    - name: OrchestratorType
+      value: 'K8S'

--- a/deploy/k8s/archived/linkerd/basket-api-sp.yaml
+++ b/deploy/k8s/archived/linkerd/basket-api-sp.yaml
@@ -1,0 +1,42 @@
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: basket-api.default.svc.cluster.local
+  namespace: default
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /basket-api/api/v1/basket/[^/]*
+    name: GET Basket {id}
+    isRetryable: true
+  - condition:
+      method: GET
+      pathRegex: /hc
+    name: GET /hc
+    isRetryable: false
+  - condition:
+      method: GET
+      pathRegex: /liveness
+    name: GET /liveness
+    isRetryable: false
+  - condition:
+      method: POST
+      pathRegex: /BasketApi\.Basket/GetBasketById
+    name: POST /BasketApi.Basket/GetBasketById
+    isRetryable: true
+  - condition:
+      method: POST
+      pathRegex: /BasketApi\.Basket/UpdateBasket
+    name: POST /BasketApi.Basket/UpdateBasket
+    isRetryable: true
+  - condition:
+      method: POST
+      pathRegex: /basket-api/api/v1/basket/checkout
+    name: POST /v1/basket/checkout
+    isRetryable: true
+  retryBudget:
+    retryRatio: 0.2
+    minRetriesPerSecond: 10
+    ttl: 10s

--- a/deploy/k8s/archived/linkerd/catalog-api-sp.yaml
+++ b/deploy/k8s/archived/linkerd/catalog-api-sp.yaml
@@ -1,0 +1,47 @@
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: catalog-api.default.svc.cluster.local
+  namespace: default
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /catalog-api/api/v1/catalog/catalogbrands
+    name: GET /v1/catalog/catalogbrands
+    isRetryable: true
+  - condition:
+      method: GET
+      pathRegex: /catalog-api/api/v1/catalog/catalogtypes
+    name: GET /v1/catalog/catalogtypes
+    isRetryable: true
+  - condition:
+      method: GET
+      pathRegex: /catalog-api/api/v1/catalog/items
+    name: GET /v1/catalog/items
+    isRetryable: true
+  - condition:
+      method: GET
+      pathRegex: /api/v1/catalog/items/[^/]*/pic/
+    name: GET /v1/catalog/items/{id}/pic/
+    isRetryable: false
+  - condition:
+      method: GET
+      pathRegex: /hc
+    name: GET /hc
+    isRetryable: false
+  - condition:
+      method: GET
+      pathRegex: /liveness
+    isRetryable: false
+    name: GET /liveness
+  - condition:
+      method: POST
+      pathRegex: /CatalogApi\.Catalog/GetItemsByIds
+    name: POST /CatalogApi.Catalog/GetItemsByIds
+    isRetryable: true
+  retryBudget:
+    retryRatio: 0.2
+    minRetriesPerSecond: 10
+    ttl: 10s

--- a/deploy/k8s/archived/nginx-ingress/local-cm.yaml
+++ b/deploy/k8s/archived/nginx-ingress/local-cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  name: nginx-configuration
+  namespace: ingress-nginx
+data:
+  proxy-buffer-size: "128k"
+  proxy-buffers: "4 256k"

--- a/deploy/k8s/archived/nginx-ingress/local-dockerk8s/identityapi-cm-fix.yaml
+++ b/deploy/k8s/archived/nginx-ingress/local-dockerk8s/identityapi-cm-fix.yaml
@@ -1,0 +1,3 @@
+data:
+  mvc_e: http://10.0.75.1/webmvc
+  

--- a/deploy/k8s/archived/nginx-ingress/local-dockerk8s/mvc-cm-fix.yaml
+++ b/deploy/k8s/archived/nginx-ingress/local-dockerk8s/mvc-cm-fix.yaml
@@ -1,0 +1,3 @@
+data:
+  urls__IdentityUrl: http://10.0.75.1/identity
+  urls__mvc: http://10.0.75.1/webmvc

--- a/deploy/k8s/archived/nginx-ingress/local-dockerk8s/mvc-fix.yaml
+++ b/deploy/k8s/archived/nginx-ingress/local-dockerk8s/mvc-fix.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  labels:
+    app: webmvc
+  name: eshop-webmvc-loopback
+  namespace: default
+spec:
+  rules:
+  - http: 
+      paths:
+      - backend:
+          serviceName: webmvc
+          servicePort: http
+        path: /webmvc
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  labels:
+    app: identity-api
+  name: eshop-identity-api-loopback
+  namespace: default
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: identity
+          servicePort: http
+        path: /identity

--- a/deploy/k8s/archived/nginx-ingress/local-svc.yaml
+++ b/deploy/k8s/archived/nginx-ingress/local-svc.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/deploy/k8s/archived/nginx-ingress/mandatory.yaml
+++ b/deploy/k8s/archived/nginx-ingress/mandatory.yaml
@@ -1,0 +1,238 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-clusterrole
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-clusterrole-nisa-binding
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: nginx-ingress-serviceaccount
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0
+          args:
+            - /nginx-ingress-controller
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 33
+            runAsUser: 33
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1

--- a/deploy/k8s/archived/nginx-ingress/service-nodeport.yaml
+++ b/deploy/k8s/archived/nginx-ingress/service-nodeport.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/deploy/k8s/archived/nodeports/rabbitmq-admin.yaml
+++ b/deploy/k8s/archived/nodeports/rabbitmq-admin.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: rabbitmq-admin
+spec:
+  type: NodePort
+  selector:
+    app: rabbitmq
+  ports:
+    - port: 15672
+      nodePort: 31672
+      name: rabbitmq-port

--- a/deploy/k8s/archived/nodeports/sql-service.yaml
+++ b/deploy/k8s/archived/nodeports/sql-service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: sql-service
+spec:
+  type: NodePort
+  selector:
+    app: sql-data
+  ports:
+    - port: 1433
+      nodePort: 31433
+      name: sql-port

--- a/deploy/k8s/helm/apigwmm/templates/deployment.yaml
+++ b/deploy/k8s/helm/apigwmm/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $name := include "apigwmm.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
 {{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "apigwmm.fullname" . }}

--- a/deploy/k8s/helm/apigwms/templates/deployment.yaml
+++ b/deploy/k8s/helm/apigwms/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $name := include "apigwms.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
 {{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "apigwms.fullname" . }}

--- a/deploy/k8s/helm/apigwwm/templates/deployment.yaml
+++ b/deploy/k8s/helm/apigwwm/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $name := include "apigwwm.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
 {{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "apigwwm.fullname" . }}

--- a/deploy/k8s/helm/apigwws/templates/deployment.yaml
+++ b/deploy/k8s/helm/apigwws/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $name := include "apigwws.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
 {{- $envoycfgname := printf "%s-%s" "envoy" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "apigwws.fullname" . }}

--- a/deploy/k8s/helm/basket-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/basket-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "basket-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "basket-api.fullname" . }}

--- a/deploy/k8s/helm/basket-data/templates/deployment.yaml
+++ b/deploy/k8s/helm/basket-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "basket-data.fullname" . }}

--- a/deploy/k8s/helm/catalog-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/catalog-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "catalog-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "catalog-api.fullname" . }}

--- a/deploy/k8s/helm/deploy-all-mac.ps1
+++ b/deploy/k8s/helm/deploy-all-mac.ps1
@@ -1,0 +1,156 @@
+Param(
+    [parameter(Mandatory=$false)][string]$registry,
+    [parameter(Mandatory=$false)][string]$dockerUser,
+    [parameter(Mandatory=$false)][string]$dockerPassword,
+    [parameter(Mandatory=$false)][string]$externalDns,
+    [parameter(Mandatory=$false)][string]$appName="eshop",
+    [parameter(Mandatory=$false)][bool]$deployInfrastructure=$true,
+    [parameter(Mandatory=$false)][bool]$deployCharts=$true,
+    [parameter(Mandatory=$false)][bool]$clean=$true,
+    [parameter(Mandatory=$false)][string]$aksName="",
+    [parameter(Mandatory=$false)][string]$aksRg="",
+    [parameter(Mandatory=$false)][string]$imageTag="latest",
+    [parameter(Mandatory=$false)][bool]$useLocalk8s=$false,
+    [parameter(Mandatory=$false)][bool]$useMesh=$false,
+    [parameter(Mandatory=$false)][string][ValidateSet('Always','IfNotPresent','Never', IgnoreCase=$false)]$imagePullPolicy="Always",
+    [parameter(Mandatory=$false)][string][ValidateSet('prod','staging','none','custom', IgnoreCase=$false)]$sslSupport = "none",
+    [parameter(Mandatory=$false)][string]$tlsSecretName = "eshop-tls-custom",
+    [parameter(Mandatory=$false)][string]$chartsToDeploy="*",
+    [parameter(Mandatory=$false)][string]$ingressMeshAnnotationsFile="ingress_values_linkerd.yaml"
+    )
+
+function Install-Chart  {
+    Param([string]$chart,[string]$initialOptions, [bool]$customRegistry)
+    $options=$initialOptions
+    if ($sslEnabled) {
+        $options = "$options --set ingress.tls[0].secretName=$tlsSecretName --set ingress.tls[0].hosts=`{$dns`}" 
+        if ($sslSupport -ne "custom") {
+            $options = "$options --set inf.tls.issuer=$sslIssuer"
+        }
+    }
+    if ($customRegistry) {
+        $options = "$options --set inf.registry.server=$registry --set inf.registry.login=$dockerUser --set inf.registry.pwd=$dockerPassword --set inf.registry.secretName=eshop-docker-scret"
+    }
+    
+    if ($chart -ne "eshop-common" -or $customRegistry)  {       # eshop-common is ignored when no secret must be deployed        
+        
+        $command = "helm install $appName-$chart $options $chart"
+        Write-Host "Helm Command: $command" -ForegroundColor Gray        
+        Invoke-Expression $command
+    }
+}
+
+$dns = $externalDns
+$sslEnabled=$false
+$sslIssuer=""
+
+if ($sslSupport -eq "staging") {
+    $sslEnabled=$true
+    $tlsSecretName="eshop-letsencrypt-staging"
+    $sslIssuer="letsencrypt-staging"
+}
+elseif ($sslSupport -eq "prod") {
+    $sslEnabled=$true
+    $tlsSecretName="eshop-letsencrypt-prod"
+    $sslIssuer="letsencrypt-prod"
+}
+elseif ($sslSupport -eq "custom") {
+    $sslEnabled=$true
+}
+
+$ingressValuesFile="ingress_values.yaml"
+
+if ($useLocalk8s -eq $true) {
+    $ingressValuesFile="ingress_values_dockerk8s.yaml"
+    $dns="localhost"
+}
+
+if ($externalDns -eq "aks") {
+    if  ([string]::IsNullOrEmpty($aksName) -or [string]::IsNullOrEmpty($aksRg)) {
+        Write-Host "Error: When using -dns aks, MUST set -aksName and -aksRg too." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Getting DNS of AKS of AKS $aksName (in resource group $aksRg)..." -ForegroundColor Green
+    $dns = $(az aks show -n $aksName  -g $aksRg --query addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName)
+    if ([string]::IsNullOrEmpty($dns)) {
+        Write-Host "Error getting DNS of AKS $aksName (in resource group $aksRg). Please ensure AKS has httpRouting enabled AND Azure CLI is logged & in version 2.0.37 or higher" -ForegroundColor Red
+        exit 1
+    }
+    $dns = $dns -replace '[\"]'
+    Write-Host "DNS base found is $dns. Will use $appName.$dns for the app!" -ForegroundColor Green
+    $dns = "$appName.$dns"
+}
+
+# Initialization & check commands
+if ([string]::IsNullOrEmpty($dns)) {
+    Write-Host "No DNS specified. Ingress resources will be bound to public ip" -ForegroundColor Yellow
+    if ($sslEnabled) {
+        Write-Host "Can't bound SSL to public IP. DNS is mandatory when using TLS" -ForegroundColor Red
+        exit 1
+    }
+}
+
+if ($useLocalk8s -and $sslEnabled) {
+    Write-Host "SSL can'be enabled on local K8s." -ForegroundColor Red
+    exit 1
+}
+
+if ($clean) {    
+    $listOfReleases=$(helm ls --filter eshop -q)    
+    if ([string]::IsNullOrEmpty($listOfReleases)) {
+        Write-Host "No previous releases found!" -ForegroundColor Green
+	}else{
+        Write-Host "Previous releases found" -ForegroundColor Green
+        Write-Host "Cleaning previous helm releases..." -ForegroundColor Green
+        helm uninstall $listOfReleases
+        Write-Host "Previous releases deleted" -ForegroundColor Green
+	}        
+}
+
+$useCustomRegistry=$false
+
+if (-not [string]::IsNullOrEmpty($registry)) {
+    $useCustomRegistry=$true
+    if ([string]::IsNullOrEmpty($dockerUser) -or [string]::IsNullOrEmpty($dockerPassword)) {
+        Write-Host "Error: Must use -dockerUser AND -dockerPassword if specifying custom registry" -ForegroundColor Red
+        exit 1
+    }
+}
+
+Write-Host "Begin eShopOnContainers installation using Helm" -ForegroundColor Green
+
+$infras = ("sql-data", "nosql-data", "rabbitmq", "keystore-data", "basket-data")
+$charts = ("eshop-common", "basket-api","catalog-api", "identity-api", "locations-api", "marketing-api", "mobileshoppingagg","ordering-api","ordering-backgroundtasks","ordering-signalrhub", "payment-api", "webmvc", "webshoppingagg", "webspa", "webstatus", "webhooks-api", "webhooks-web")
+$gateways = ("apigwmm", "apigwms", "apigwwm", "apigwws")
+
+if ($deployInfrastructure) {
+    foreach ($infra in $infras) {
+        Write-Host "Installing infrastructure: $infra" -ForegroundColor Green
+        helm install "$appName-$infra" --values app.yaml --values inf.yaml --values $ingressValuesFile --set app.name=$appName --set inf.k8s.dns=$dns --set "ingress.hosts={$dns}" $infra     
+    }
+}
+else {
+    Write-Host "eShopOnContainers infrastructure (bbdd, redis, ...) charts aren't installed (-deployCharts is false)" -ForegroundColor Yellow
+}
+
+if ($deployCharts) {
+    foreach ($chart in $charts) {
+        if ($chartsToDeploy -eq "*" -or $chartsToDeploy.Contains($chart)) {
+            Write-Host "Installing: $chart" -ForegroundColor Green
+            Install-Chart $chart "--values app.yaml --values inf.yaml --values $ingressValuesFile --values $ingressMeshAnnotationsFile --set app.name=$appName --set inf.k8s.dns=$dns --set ingress.hosts=``{$dns``} --set image.tag=$imageTag --set image.pullPolicy=$imagePullPolicy --set inf.tls.enabled=$sslEnabled --set inf.mesh.enabled=$useMesh --set inf.k8s.local=$useLocalk8s" $useCustomRegistry
+        }
+    }
+
+    foreach ($chart in $gateways) {
+        if ($chartsToDeploy -eq "*" -or $chartsToDeploy.Contains($chart)) {
+            Write-Host "Installing Api Gateway Chart: $chart" -ForegroundColor Green
+            Install-Chart $chart "--values app.yaml --values inf.yaml --values $ingressValuesFile  --set app.name=$appName --set inf.k8s.dns=$dns  --set image.pullPolicy=$imagePullPolicy --set inf.mesh.enabled=$useMesh --set ingress.hosts=``{$dns``} --set inf.tls.enabled=$sslEnabled" $false
+            
+        }
+    }
+}
+else {
+    Write-Host "eShopOnContainers non-infrastructure charts aren't installed (-deployCharts is false)" -ForegroundColor Yellow
+}
+
+Write-Host "helm charts installed." -ForegroundColor Green

--- a/deploy/k8s/helm/deploy-all.sh
+++ b/deploy/k8s/helm/deploy-all.sh
@@ -201,7 +201,7 @@ if [[ $clean ]]; then
   if [[ -z $(helm ls -q --namespace $namespace) ]]; then
     echo "No previous releases found"
   else
-    helm delete --purge $(helm ls -q --namespace $namespace)
+    helm uninstall $(helm ls -q --namespace $namespace)
     echo "Previous releases deleted"
     waitsecs=10; while [ $waitsecs -gt 0 ]; do echo -ne "$waitsecs\033[0K\r"; sleep 1; : $((waitsecs--)); done
   fi
@@ -215,7 +215,7 @@ if [[ !$skip_infrastructure ]]; then
   for infra in "${infras[@]}"
   do
     echo "Installing infrastructure: $infra"
-    helm install --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --name="$app_name-$infra" $infra     
+    helm install "$app_name-$infra" --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns $infra     
   done  
 fi
 
@@ -223,9 +223,9 @@ for chart in "${charts[@]}"
 do
     echo "Installing: $chart"
     if [[ $use_custom_registry ]]; then 
-      helm install --namespace $namespace --set "ingress.hosts={$dns}" --set inf.registry.server=$container_registry --set inf.registry.login=$docker_username --set inf.registry.pwd=$docker_password --set inf.registry.secretName=eshop-docker-scret --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always --name="$app_name-$chart" $chart 
+      helm install "$app_name-$chart" --namespace $namespace --set "ingress.hosts={$dns}" --set inf.registry.server=$container_registry --set inf.registry.login=$docker_username --set inf.registry.pwd=$docker_password --set inf.registry.secretName=eshop-docker-scret --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always $chart 
     elif [[ $chart != "eshop-common" ]]; then  # eshop-common is ignored when no secret must be deployed
-      helm install --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always --name="$app_name-$chart" $chart 
+      helm install "$app_name-$chart" --namespace $namespace --set "ingress.hosts={$dns}" --values app.yaml --values inf.yaml --values $ingress_values_file --set app.name=$app_name --set inf.k8s.dns=$dns --set image.tag=$image_tag --set image.pullPolicy=Always $chart 
     fi
 done
 

--- a/deploy/k8s/helm/identity-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/identity-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "identity-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "identity-api.fullname" . }}

--- a/deploy/k8s/helm/keystore-data/templates/deployment.yaml
+++ b/deploy/k8s/helm/keystore-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "keystore-data.fullname" . }}

--- a/deploy/k8s/helm/locations-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/locations-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "locations-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locations-api.fullname" . }}

--- a/deploy/k8s/helm/marketing-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/marketing-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "marketing-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "marketing-api.fullname" . }}

--- a/deploy/k8s/helm/mobileshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/helm/mobileshoppingagg/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "mobileshoppingagg.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mobileshoppingagg.fullname" . }}

--- a/deploy/k8s/helm/nosql-data/templates/deployment.yaml
+++ b/deploy/k8s/helm/nosql-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nosql-data.fullname" . }}

--- a/deploy/k8s/helm/ordering-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "ordering-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ordering-api.fullname" . }}

--- a/deploy/k8s/helm/ordering-backgroundtasks/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-backgroundtasks/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $name := include "ordering-backgroundtasks.fullname" . -}}
 {{- $cfgname :=  printf "cfg-%s" $name | trunc 63  }}
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ordering-backgroundtasks.fullname" . }}

--- a/deploy/k8s/helm/ordering-signalrhub/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-signalrhub/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "ordering-signalrhub.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ordering-signalrhub.fullname" . }}

--- a/deploy/k8s/helm/payment-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/payment-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "payment-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "payment-api.fullname" . }}

--- a/deploy/k8s/helm/rabbitmq/templates/deployment.yaml
+++ b/deploy/k8s/helm/rabbitmq/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "rabbitmq.fullname" . }}

--- a/deploy/k8s/helm/sql-data/templates/deployment.yaml
+++ b/deploy/k8s/helm/sql-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sql-data.fullname" . }}

--- a/deploy/k8s/helm/webhooks-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webhooks-api.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webhooks-api.fullname" . }}

--- a/deploy/k8s/helm/webhooks-web/templates/deployment.yaml
+++ b/deploy/k8s/helm/webhooks-web/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webhooks-web.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webhooks-web.fullname" . }}

--- a/deploy/k8s/helm/webmvc/templates/deployment.yaml
+++ b/deploy/k8s/helm/webmvc/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webmvc.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webmvc.fullname" . }}

--- a/deploy/k8s/helm/webshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/helm/webshoppingagg/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webshoppingagg.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webshoppingagg.fullname" . }}

--- a/deploy/k8s/helm/webspa/templates/deployment.yaml
+++ b/deploy/k8s/helm/webspa/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webspa.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webspa.fullname" . }}

--- a/deploy/k8s/helm/webstatus/templates/deployment.yaml
+++ b/deploy/k8s/helm/webstatus/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "webstatus.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webstatus.fullname" . }}

--- a/deploy/k8s/nginx-ingress/mandatory.yaml
+++ b/deploy/k8s/nginx-ingress/mandatory.yaml
@@ -163,7 +163,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller


### PR DESCRIPTION
This pull request primarily address fix #1370. It includes following changes :

1. Supported deployment through helm 3.x.
2. Updated k8s deployment related scripts for version 1.16.x+
3. Moved older scripts to `k8s/archived` directory. 
4. Introduced `deploy-all-mac.ps1` for MacOS powershell environment.
