### PR TITLE
Updated serialize-javascript version to 3.1.0

### DIFF
--- a/src/Web/WebSPA/package-lock.json
+++ b/src/Web/WebSPA/package-lock.json
@@ -1478,8 +1478,8 @@
           }
         },
         "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
           "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
           "dev": true
         },


### PR DESCRIPTION
Updated serialize-javascript version from 2.1.1 to 3.1.0 as suggested :  https://github.com/dotnet-architecture/eShopOnContainers/network/alert/src/Web/WebSPA/package-lock.json/serialize-javascript/open