### PR TITLE
#1397: Replaced docker.for.win.localhost by host.docker.internal

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -5,9 +5,9 @@
 # The IP below should be swapped to your real IP or DNS name, like 192.168.88.248, etc. if testing from remote browsers or mobile devices
 
 # Use this values to run the app locally in Windows
-ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.win.localhost
-ESHOP_STORAGE_CATALOG_URL=http://docker.for.win.localhost:5202/c/api/v1/catalog/items/[0]/pic/
-ESHOP_STORAGE_MARKETING_URL=http://docker.for.win.localhost:5110/api/v1/campaigns/[0]/pic/
+ESHOP_EXTERNAL_DNS_NAME_OR_IP=host.docker.internal
+ESHOP_STORAGE_CATALOG_URL=http://host.docker.internal:5202/c/api/v1/catalog/items/[0]/pic/
+ESHOP_STORAGE_MARKETING_URL=http://host.docker.internal:5110/api/v1/campaigns/[0]/pic/
 
 # Use this values to run the app locally in Mac
 # ESHOP_EXTERNAL_DNS_NAME_OR_IP=docker.for.mac.localhost


### PR DESCRIPTION
... in src/.env
see #1397 