### PR TITLE
Change ReadAllBytes to ReadAllBytesAsync in PicController

### DIFF
--- a/src/Services/Catalog/Catalog.API/Controllers/PicController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/PicController.cs
@@ -46,7 +46,7 @@ namespace Microsoft.eShopOnContainers.Services.Catalog.API.Controllers
                 string imageFileExtension = Path.GetExtension(item.PictureFileName);
                 string mimetype = GetImageMimeTypeFromImageFileExtension(imageFileExtension);
 
-                var buffer = System.IO.File.ReadAllBytes(path);
+                var buffer = await System.IO.File.ReadAllBytesAsync(path);
 
                 return File(buffer, mimetype);
             }


### PR DESCRIPTION
Changing File.ReadAllBytes to await File.ReadAllBytesAsync in order to liberate the thread when reading the file.