### PR TITLE
Fix api version for deployment

### DIFF
--- a/deploy/k8s/nginx-ingress/mandatory.yaml
+++ b/deploy/k8s/nginx-ingress/mandatory.yaml
@@ -163,7 +163,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller


### PR DESCRIPTION
Seems like a old version of the manifest. Corrected to use apps/v1.