### PR TITLE
Fix login issue Exception: Correlation failed

### DIFF
--- a/src/Web/WebMVC/Startup.cs
+++ b/src/Web/WebMVC/Startup.cs
@@ -82,6 +82,10 @@ namespace Microsoft.eShopOnContainers.WebMVC
             }
 
             WebContextSeed.Seed(app, env);
+            
+            // Fix samesite issue when running eShop from docker-compose locally as by default http protocol is being used
+            // Refer to https://github.com/dotnet-architecture/eShopOnContainers/issues/1391
+            app.UseCookiePolicy(new CookiePolicyOptions { MinimumSameSitePolicy = AspNetCore.Http.SameSiteMode.Lax });            
 
             app.UseRouting();
             


### PR DESCRIPTION
Fix samesite issue when running eShop from docker-compose locally as by default http protocol is being used
Refer to https://github.com/dotnet-architecture/eShopOnContainers/issues/1391