### PR TITLE
Fix PurchaseUrl port in WebSPA appsettings.json

### DIFF
--- a/src/Web/WebSPA/appsettings.json
+++ b/src/Web/WebSPA/appsettings.json
@@ -2,7 +2,7 @@
   "IdentityUrl": "http://localhost:5105",
   "MarketingUrl": "http://localhost:5110",
   "CallBackUrl": "http://localhost:5104/",
-  "PurchaseUrl": "http://localhost:5200",
+  "PurchaseUrl": "http://localhost:5202",
   "PurchaseUrlHC": "http://localhost:5202/hc",
   "MarketingUrlHC": "http://localhost:5203/hc",
   "IdentityUrlHC": "http://localhost:5105/hc",


### PR DESCRIPTION
Hi,
in the WebSPA project's appsettings.json the port of PurchaseUrl seems to be wrong but it doesn't cause errors because the matching environment variable in docker-compose.override.yml overrides it.
Commenting out the environment variable results in the catalog not being shown and console errors like:

Access to XMLHttpRequest at 'http://localhost:5200/c/api/v1/catalog/items?pageIndex=0&pageSize=10' from origin 'http://host.docker.internal:5104' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.

The change in this PR fixes it.